### PR TITLE
`--` を引数区切りとして機能させる

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,8 +37,8 @@ pub struct BundleArgs {
     /// C++ source file to bundle
     pub file: PathBuf,
 
-    /// Extra options passed through to the compiler
-    #[arg(last = true)]
+    /// Extra options after `--` passed straight to the compiler
+    #[arg(last = true, value_name = "COMPILER OPTIONS")]
     pub options: Vec<String>,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub struct BundleArgs {
     pub file: PathBuf,
 
     /// Extra options passed through to the compiler
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    #[arg(last = true)]
     pub options: Vec<String>,
 }
 
@@ -89,4 +89,29 @@ pub enum LibraryCommand {
         #[arg(short, long)]
         verbose: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_after_file_are_parsed_as_risundle_flags() {
+        let args = BundleArgs::try_parse_from(["risundle", "main.cpp", "-e"]).unwrap();
+        assert!(args.embed);
+        assert!(args.options.is_empty());
+    }
+
+    #[test]
+    fn double_dash_separates_compiler_options() {
+        let args =
+            BundleArgs::try_parse_from(["risundle", "main.cpp", "--", "-std=gnu++20", "-O2"])
+                .unwrap();
+        assert_eq!(args.options, ["-std=gnu++20", "-O2"]);
+    }
+
+    #[test]
+    fn hyphen_arguments_before_double_dash_are_rejected() {
+        assert!(BundleArgs::try_parse_from(["risundle", "main.cpp", "-O2"]).is_err());
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -215,7 +215,11 @@ fn run_bundle(sandbox: &Sandbox, args: &[&str]) -> String {
         .arg("main.cpp")
         .output()
         .expect("run bundle");
-    assert!(output.status.success(), "bundle failed");
+    assert!(
+        output.status.success(),
+        "bundle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     String::from_utf8(output.stdout).expect("utf-8")
 }
 
@@ -359,7 +363,11 @@ fn bundle_passes_options_after_double_dash_to_compiler() {
         .args(["-k", STD, "main.cpp", "--", "-DRISUNDLE_TEST_ANSWER=0"])
         .output()
         .expect("run bundle");
-    assert!(output.status.success(), "bundle failed");
+    assert!(
+        output.status.success(),
+        "bundle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let bundled = String::from_utf8(output.stdout).expect("utf-8");
     assert!(
         bundled.contains("return 0"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -345,6 +345,29 @@ fn bundle_ignores_identifiers_in_comments_and_strings() {
 }
 
 #[test]
+fn bundle_passes_options_after_double_dash_to_compiler() {
+    let sandbox = Sandbox::new();
+    sandbox.write(
+        "main.cpp",
+        "#ifdef RISUNDLE_TEST_ANSWER\nint main() { return RISUNDLE_TEST_ANSWER; }\n\
+        #else\n#error RISUNDLE_TEST_ANSWER is not defined\n#endif\n",
+    );
+
+    // -D が届かなければ #error でプリプロセスごと失敗するので、成功 = 受け渡しの証明。
+    let output = sandbox
+        .risundle()
+        .args(["-k", STD, "main.cpp", "--", "-DRISUNDLE_TEST_ANSWER=0"])
+        .output()
+        .expect("run bundle");
+    assert!(output.status.success(), "bundle failed");
+    let bundled = String::from_utf8(output.stdout).expect("utf-8");
+    assert!(
+        bundled.contains("return 0"),
+        "-D で定義したマクロが展開されるべき"
+    );
+}
+
+#[test]
 fn embed_includes_original_source_as_comment() {
     let sandbox = Sandbox::new();
     let main = "int main() { return 0; }\n";


### PR DESCRIPTION
Closes #23

## 変更内容

`src/cli.rs` の `options` を `trailing_var_arg = true, allow_hyphen_values = true` から `last = true` に変更しました。clap の `last` はその引数を `--` の後ろ限定にするもので、Issue の要求と一対一に対応します。

- `--` より後ろだけがコンパイラへ渡るようになる
- `<file>` の後ろに書いた risundle のオプション (`risundle main.cpp -e` など) も解釈される
- `--` 無しでハイフン引数を書くと unknown option としてエラーになる (これまで黙ってコンパイラへ流れていたのがフェイルファストに)

usage 表示も `[-- <OPTIONS>...]` に自動で変わり、README の記載 (`risundle [OPTIONS] <FILE> [-- <COMPILER OPTIONS>...]`) が初めて実挙動と一致します。ドキュメント側は元から desired behavior で書かれていたため変更不要でした。

## テスト

- `src/cli.rs` にパースのユニットテスト 3 本 (ファイル後のオプション解釈 / `--` 区切り / `--` 前のハイフン引数拒否)
- `tests/cli.rs` に結合テスト 1 本 (`-- -D<macro>` がコンパイラへ届くことを `#error` ガードで証明)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwiopnwyFnRbSUyNoFLWAZ
