### PR TITLE
v1.1.0 にバージョンアップ

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,3 +123,4 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: ${{ env.ASSET }}
+          generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "risundle"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risundle"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2024"
 authors = ["TwoSquirrels"]
 description = "A C++ bundler with tree-shaking for competitive programming"


### PR DESCRIPTION
v1.1 マイルストーン (#22, #23) 消化に伴うリリース準備です。マージ後に `v1.1.0` タグでリリースします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwiopnwyFnRbSUyNoFLWAZ