### PR TITLE
docs: 固有名詞を正式名称に統一

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,12 +112,12 @@ embed = false
 
 ## ベンチマーク
 
-IWYU (include-what-you-use 0.21) と実行時間を比較しました。環境は WSL2 (Ubuntu 24.04、Intel Core 7 240H、g++ 14.2) です。
+IWYU (include-what-you-use 0.21) と実行時間を比較しました。環境は WSL 2 (Ubuntu 24.04、Intel Core 7 240H、g++ 14.2) です。
 
 | ライブラリ | risundle | IWYU |
 | --- | --- | --- |
 | AC Library | 0.031 秒 | 0.491 秒 |
-| Nyaan Library | 0.033 秒 | 2.085 秒 |
+| Nyaan's Library | 0.033 秒 | 2.085 秒 |
 
 risundle はライブラリ規模によらずほぼ一定で、IWYU はヘッダー数が増えるほど伸びます。IWYU は clang の AST をフル構築するのに対し、risundle はコンパイラのプリプロセス (`-E`/`-M`) だけで完結するためです。なお IWYU と risundle は目的が異なり (IWYU は `#include` の修正提案、risundle はバンドル)、同じ問題を解くツールではありません。
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ The above are the default values. Omitted items are filled in with these default
 
 ## Benchmarks
 
-We compared execution time against IWYU (include-what-you-use 0.21). The environment was WSL2 (Ubuntu 24.04, Intel Core 7 240H, g++ 14.2).
+We compared execution time against IWYU (include-what-you-use 0.21). The environment was WSL 2 (Ubuntu 24.04, Intel Core 7 240H, g++ 14.2).
 
 | Library | risundle | IWYU |
 | --- | --- | --- |
 | AC Library | 0.031 s | 0.491 s |
-| Nyaan Library | 0.033 s | 2.085 s |
+| Nyaan's Library | 0.033 s | 2.085 s |
 
 risundle stays nearly constant regardless of library size, while IWYU grows as the number of headers increases. This is because IWYU fully builds the clang AST, whereas risundle relies solely on the compiler's preprocessing (`-E`/`-M`). Note that IWYU and risundle serve different purposes (IWYU suggests `#include` fixes; risundle bundles) and do not solve the same problem.
 

--- a/docs/cheatsheet.ja.md
+++ b/docs/cheatsheet.ja.md
@@ -73,7 +73,7 @@ oj t && risundle main.cpp > submission.cpp && oj s submission.cpp
 
 ### ジャッジに入っているライブラリは展開せず `#include` のまま残したい
 
-例: AtCoder Library がジャッジ側にあるので埋め込みたくない。
+例: AC Library がジャッジ側にあるので埋め込みたくない。
 
 ```bash
 risundle -k std -k ac-library main.cpp > submission.cpp

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -74,7 +74,7 @@ oj t && risundle main.cpp > submission.cpp && oj s submission.cpp
 
 ### Leave a library the judge already has as `#include`, unexpanded
 
-Example: the judge provides the AtCoder Library, so you don't want it embedded.
+Example: the judge provides AC Library, so you don't want it embedded.
 
 ```bash
 risundle -k std -k ac-library main.cpp > submission.cpp


### PR DESCRIPTION
ドキュメント中の固有名詞を正式名称に揃えます。

| 修正前 | 修正後 | 根拠 |
| --- | --- | --- |
| Nyaan Library | Nyaan's Library | 正式名称 (README ベンチマーク表、両言語) |
| AtCoder Library | AC Library | 本家リポジトリ README・公式ドキュメントの自称。risundle 内の他の箇所も AC Library で統一済みだった (チートシート両言語の各 1 箇所のみ揺れ) |
| WSL2 | WSL 2 | Microsoft 公式表記 (README ベンチマーク環境、両言語) |

コード変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwiopnwyFnRbSUyNoFLWAZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark wording and table labels for clearer, more consistent naming.
  * Refined spacing and formatting in the benchmarks section.
  * Replaced example library names in the cheatsheet with the newer AC Library wording in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->