### PR TITLE
テストを強化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,37 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
-  # macOS/Windows はユニットテストとビルド健全性のみ (--bins)。tests/ 配下の統合・E2E テストは
-  # GCC 専用 (<bits/stdc++.h> や実 GCC ライブラリ) で clang/MinGW では動かないため、ここでは走らせない。
-  # それらフルスイートは下の coverage ジョブ (Linux + g++ + submodules) で実行している。
+  # OS とコンパイラの各軸を最低 1 回ずつ踏むフルスイート (ユニット + tests/ の統合・E2E)。
+  # Ubuntu + g++ の組は下の coverage ジョブが兼ねるためここには置かない。E2E のコンパイラは
+  # RISUNDLE_TEST_COMPILER で切り替わり、<bits/stdc++.h> に依存するテストはそれを提供しない
+  # コンパイラ (libc++ の Apple clang 等) で自己スキップする。Windows の clang++ は既定で MSVC の
+  # 標準ライブラリと繋がる特殊構成のため対象外。
   test:
-    name: test (${{ matrix.os }})
+    name: test (${{ matrix.os }}, ${{ matrix.compiler }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-26-intel, windows-latest]
+        include:
+          - os: ubuntu-latest
+            compiler: clang++
+          - os: macos-latest
+            compiler: clang++
+          - os: macos-26-intel
+            compiler: clang++
+          - os: windows-latest
+            compiler: g++
+    env:
+      RISUNDLE_TEST_COMPILER: ${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          submodules: recursive
           persist-credentials: false
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo test --locked --all-features --bins
+      # ランナー標準のコンパイラに依存しているため、無ければここで分かりやすく落とす。
+      - run: ${{ matrix.compiler }} --version
+      - run: cargo test --locked --all-features
 
   # Linux のフルスイート (ユニット + tests/ の統合・E2E) を計測し、Pages へカバレッジを公開する。
   coverage:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +593,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "dirs",
+ "dunce",
  "logos",
  "predicates",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter = "0.26.9"
 tree-sitter-cpp = "0.23.4"
 sha2 = "0.11.0"
 logos = "0.16.1"
+dunce = "1.0.5"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 
 ## インストール
 
-[Rust ツールチェーン](https://www.rust-lang.org/tools/install) と C++ コンパイラ (`g++` など) が必要です。
+[Rust ツールチェーン](https://www.rust-lang.org/tools/install) と、GCC 互換の C++ コンパイラ (`g++` や `clang++` など) が必要です。risundle が依存する `-E`/`-M`/`-v` オプションを持たない MSVC には対応していません。
 
 ```bash
 cargo install risundle

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ risundle bundles your competitive programming solution, libraries included, into
 
 ## Installation
 
-You need the [Rust toolchain](https://www.rust-lang.org/tools/install) and a C++ compiler (such as `g++`).
+You need the [Rust toolchain](https://www.rust-lang.org/tools/install) and a C++ compiler with a GCC-compatible driver interface, such as `g++` or `clang++` (MSVC is not supported, as it lacks the `-E`/`-M`/`-v` interface risundle relies on).
 
 ```bash
 cargo install risundle

--- a/docs/spec.ja.md
+++ b/docs/spec.ja.md
@@ -10,7 +10,7 @@ README より踏み込んだ、各コマンドの挙動・エラー条件・出�
 - tree-shaking は識別子名の照合による近似で、厳密な依存解析はしない。過剰に残す方向へ倒しているため必要なコードが誤って消えることは起きにくく、万一取りこぼしても提出時のコンパイルエラーで気づける。
 - マクロは展開される。ローカルデバッグ用の `#include` も tree-shaking の対象にできるようにするため。
 - 複数ソースファイルのバンドルには対応しない。
-- 登録済みライブラリなどの内部データは、[`dirs::data_local_dir()`](https://docs.rs/dirs/latest/dirs/fn.data_local_dir.html) 配下の `risundle` ディレクトリ (以後 `$LOCAL`) に保存する。
+- 登録済みライブラリなどの内部データは、[`dirs::data_local_dir()`](https://docs.rs/dirs/latest/dirs/fn.data_local_dir.html) 配下の `risundle` ディレクトリ (以後 `$LOCAL`) に保存する。環境変数 `RISUNDLE_DATA_HOME` を設定すると、どの OS でも基準ディレクトリを上書きできる (意味は `XDG_DATA_HOME` と同じ)。
 
 ## `library` サブコマンド
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -10,7 +10,7 @@ This document goes deeper than the README, covering each command's behavior, err
 - Tree-shaking is an approximation based on identifier-name matching, not strict dependency analysis. It errs toward keeping too much, so needed code is rarely removed by mistake, and even if something is missed, you notice it through a compile error at submission time.
 - Macros are expanded. This is so that `#include`s used only for local debugging can also be subject to tree-shaking.
 - Bundling multiple source files is not supported.
-- Internal data such as registered libraries is stored under a `risundle` directory inside [`dirs::data_local_dir()`](https://docs.rs/dirs/latest/dirs/fn.data_local_dir.html) (hereafter `$LOCAL`).
+- Internal data such as registered libraries is stored under a `risundle` directory inside [`dirs::data_local_dir()`](https://docs.rs/dirs/latest/dirs/fn.data_local_dir.html) (hereafter `$LOCAL`). Setting the `RISUNDLE_DATA_HOME` environment variable overrides the base directory on every OS (same meaning as `XDG_DATA_HOME`).
 
 ## `library` subcommand
 

--- a/src/bundle/inventory.rs
+++ b/src/bundle/inventory.rs
@@ -220,7 +220,7 @@ mod tests {
     fn register(store: &LocalStore, id: &str, kind: TagsKind) -> PathBuf {
         let source = store.library_dir(id).unwrap().join("source");
         fs::create_dir_all(&source).unwrap();
-        let path = source.canonicalize().unwrap();
+        let path = dunce::canonicalize(&source).unwrap();
         Tags {
             path: path.clone(),
             kind,
@@ -473,7 +473,7 @@ mod tests {
         let source = store.library_dir("lib").unwrap().join("source");
         fs::create_dir_all(&source).unwrap();
         fs::write(source.join("a.hpp"), "struct a {};").unwrap();
-        let path = source.canonicalize().unwrap();
+        let path = dunce::canonicalize(&source).unwrap();
         let real_hash = hash::aggregate(&path).unwrap();
 
         let mut files = BTreeMap::new();

--- a/src/bundle/prune.rs
+++ b/src/bundle/prune.rs
@@ -30,19 +30,24 @@ pub fn parse_prerequisites(make_output: &str) -> BTreeSet<PathBuf> {
     prerequisites
 }
 
-/// 空白区切りでトークン化する。バックスラッシュは直後の 1 文字をエスケープ (`\ ` は空白を含む
-/// パスの一部)。行継続は呼び出し前に畳まれている前提。
+/// 空白区切りでトークン化する。make の流儀でエスケープされる空白 (`\ `) と `#` (`\#`) だけを
+/// 復元し、それ以外のバックスラッシュはそのまま残す。無差別に「直後の 1 文字」をエスケープ扱い
+/// すると、MinGW g++ が -M 出力へそのまま書く Windows パス (`C:\Users\...`) の区切りが食われて
+/// パスが壊れ、必要ヘッダーを全て取りこぼす (= 全削除) 事故になる。行継続は呼び出し前に畳まれて
+/// いる前提。
 fn tokenize(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut current = String::new();
-    let mut chars = input.chars();
+    let mut chars = input.chars().peekable();
     while let Some(ch) = chars.next() {
         match ch {
-            '\\' => {
-                if let Some(escaped) = chars.next() {
-                    current.push(escaped);
+            '\\' => match chars.peek() {
+                Some(&next @ (' ' | '#')) => {
+                    current.push(next);
+                    chars.next();
                 }
-            }
+                _ => current.push('\\'),
+            },
             ch if ch.is_whitespace() => {
                 if !current.is_empty() {
                     tokens.push(std::mem::take(&mut current));
@@ -112,6 +117,15 @@ mod tests {
     fn restores_escaped_spaces_in_paths() {
         let prerequisites = parse_prerequisites("a.o: /home/My\\ Docs/lib.hpp");
         assert!(prerequisites.contains(&PathBuf::from("/home/My Docs/lib.hpp")));
+    }
+
+    #[test]
+    fn keeps_windows_path_backslashes_intact() {
+        // MinGW g++ は Windows パスの `\` をエスケープせずそのまま出す。区切りを食うとドライブ
+        // パスが壊れ、必要ヘッダーの取りこぼし = 使用ヘッダーの誤削除に直結する。
+        let prerequisites = parse_prerequisites(r"used.o: C:\Users\me\lib\used.hpp D:/other/x.h");
+        assert!(prerequisites.contains(&PathBuf::from(r"C:\Users\me\lib\used.hpp")));
+        assert!(prerequisites.contains(&PathBuf::from("D:/other/x.h")));
     }
 
     #[test]

--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -321,3 +321,134 @@ fn run_capturing(mut command: Command, compiler: &Path, what: &str) -> Result<St
     String::from_utf8(output.stdout)
         .with_context(|| format!("the output of {what} could not be interpreted as UTF-8"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    use crate::config::Config;
+    use crate::library::local::LocalStore;
+    use crate::library::testutil::{store_in, write_std_registration};
+
+    fn empty_inventory(store: &LocalStore) -> Inventory {
+        Inventory::load(store, &BTreeSet::new()).unwrap()
+    }
+
+    /// `compiler::resolve` が通る「コンパイラ」(中身は空ファイル) を作る。警告の照合はパスの
+    /// 突き合わせだけで、起動はしない。
+    fn stub_compiler(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, "").unwrap();
+        path
+    }
+
+    #[test]
+    fn warn_std_compiler_handles_every_registration_state() {
+        // 警告は標準エラーへの出力のみで戻り値を持たないため、各経路が落ちずに通ることを確かめる
+        // (経路の選択自体は resolve と集合照合のロジックで、ここで実行される)。
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let bins = TempDir::new().unwrap();
+        let known = stub_compiler(bins.path(), "g++");
+        let unknown = stub_compiler(bins.path(), "clang++");
+
+        // std 未登録 → 登録を促す警告。
+        warn_std_compiler(&known, &empty_inventory(&store));
+
+        write_std_registration(&store, vec![std::path::absolute(&known).unwrap()]);
+        let inventory = empty_inventory(&store);
+        // 認識済みコンパイラ → 警告なし。
+        warn_std_compiler(&known, &inventory);
+        // 認識外コンパイラ → add-std を促す警告。
+        warn_std_compiler(&unknown, &inventory);
+        // 解決できないコンパイラ → 照合せず戻る (バンドル本体が改めて報告する)。
+        warn_std_compiler(Path::new("no/such/compiler"), &inventory);
+    }
+
+    #[test]
+    fn display_origin_falls_back_to_the_raw_origin() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let inventory = empty_inventory(&store);
+
+        // "/" は realpath 化できるがファイル名を持たない → 出所文字列のまま。
+        assert_eq!(display_origin("/", &inventory, None), "/");
+        // 実在しない出所 (<built-in> など) もそのまま残す。
+        assert_eq!(display_origin("<built-in>", &inventory, None), "<built-in>");
+    }
+
+    #[test]
+    fn needed_headers_without_dependencies_skips_the_compiler() {
+        // 依存ヘッダーが無ければ空集合 (= 全候補が不要)。コンパイラは起動されないので、
+        // 存在しないパスを渡しても成功することがその証明になる。
+        let needed =
+            needed_headers(Path::new("compiler-must-not-run"), &[], &BTreeSet::new()).unwrap();
+        assert!(needed.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preprocess_reports_compiler_failure_with_its_stderr() {
+        use crate::library::testutil::fake_compiler;
+
+        let scripts = TempDir::new().unwrap();
+        let cc = fake_compiler(scripts.path(), "echo 'syntax error' >&2\nexit 1");
+
+        let err = preprocess(&cc, &[], Path::new("main.cpp"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("preprocessing failed"), "{err}");
+        assert!(
+            err.contains("syntax error"),
+            "原因特定のためコンパイラの標準エラーを含めるべき: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_capturing_rejects_non_utf8_output() {
+        use crate::library::testutil::fake_compiler;
+
+        let scripts = TempDir::new().unwrap();
+        let cc = fake_compiler(scripts.path(), "printf '\\377'");
+
+        let err = preprocess(&cc, &[], Path::new("main.cpp"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not be interpreted as UTF-8"), "{err}");
+    }
+
+    #[test]
+    fn settings_prefer_cli_values_and_fall_back_to_defaults() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.cpp");
+        std::fs::write(&file, "int main() {}").unwrap();
+
+        // CLI で明示された値が勝つ。
+        let cli = Settings::resolve(
+            &file,
+            Some(PathBuf::from("my-g++")),
+            vec!["-O2".to_owned()],
+            vec!["ac-library".to_owned()],
+            true,
+        )
+        .unwrap();
+        assert_eq!(cli.compiler, PathBuf::from("my-g++"));
+        assert_eq!(cli.options, vec!["-O2".to_owned()]);
+        assert!(cli.keep.contains("ac-library"));
+        assert!(cli.embed);
+
+        // CLI 省略時は設定 (.risundlerc.toml が無いここでは組み込みデフォルト) が生きる。
+        let defaults = Settings::resolve(&file, None, vec![], vec![], false).unwrap();
+        let expected = Config::default();
+        assert_eq!(defaults.compiler, expected.compiler);
+        assert_eq!(defaults.options, expected.options);
+        assert_eq!(
+            defaults.keep,
+            expected.keep.into_iter().collect::<BTreeSet<_>>()
+        );
+        assert!(!defaults.embed);
+    }
+}

--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -55,8 +55,8 @@ pub fn run(args: BundleArgs) -> Result<()> {
     let compiler_args = compiler_args(&settings, &inventory);
     let preprocessed = preprocess(&settings.compiler, &compiler_args, &file)?;
 
-    let target = file
-        .canonicalize()
+    // canonicalize は一律 dunce 版を使う (理由は registry::resolve_source_root を参照)。
+    let target = dunce::canonicalize(&file)
         .with_context(|| format!("failed to resolve {}", file.display()))?;
     let unused = if no_tree_shaking {
         BTreeSet::new()
@@ -86,7 +86,7 @@ pub fn run(args: BundleArgs) -> Result<()> {
 /// でもなければファイル名のみへ落とす。提出物にホームディレクトリ名などローカルの絶対パスを残さない
 /// のが目的。`<built-in>` 等 realpath 化できない出所はそのまま残す (デバッグの手掛かりとして無害)。
 fn display_origin(origin: &str, inventory: &Inventory, target_dir: Option<&Path>) -> String {
-    let Ok(canonical) = Path::new(origin).canonicalize() else {
+    let Ok(canonical) = dunce::canonicalize(origin) else {
         return origin.to_owned();
     };
     if let Some(relative) = inventory.library_relative(&canonical) {
@@ -230,7 +230,7 @@ fn scan_origins(
         };
         let canonical = canonical_cache
             .entry(origin.to_owned())
-            .or_insert_with(|| Path::new(origin).canonicalize().ok())
+            .or_insert_with(|| dunce::canonicalize(origin).ok())
             .clone();
         let Some(canonical) = canonical else {
             continue; // <built-in> など実在しない出所は無視
@@ -258,7 +258,7 @@ fn needed_headers(
     let make_output = make_dependencies(compiler, compiler_args, dependency_headers)?;
     Ok(prune::parse_prerequisites(&make_output)
         .iter()
-        .filter_map(|path| path.canonicalize().ok())
+        .filter_map(|path| dunce::canonicalize(path).ok())
         .collect())
 }
 

--- a/src/commands/library.rs
+++ b/src/commands/library.rs
@@ -194,10 +194,13 @@ mod tests {
     use super::*;
 
     use std::fs;
+    use std::path::PathBuf;
 
     use tempfile::TempDir;
 
-    use crate::library::testutil::{downgrade_schema, source_with, store_in};
+    use crate::library::testutil::{
+        downgrade_schema, source_with, store_in, write_std_registration,
+    };
 
     #[test]
     fn add_rejects_std_id() {
@@ -235,6 +238,35 @@ mod tests {
         let local = TempDir::new().unwrap();
         let store = store_in(&local);
         assert!(add(&store, "lib", &local.path().join("nonexistent")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn add_std_registers_via_the_requested_compiler() {
+        use crate::library::testutil::fake_compiler_with_includes;
+
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let scripts = TempDir::new().unwrap();
+        let include = source_with(&[("vector", "// std header")]);
+        let cc = fake_compiler_with_includes(scripts.path(), include.path());
+
+        add_std(&store, Some(&cc)).unwrap();
+
+        assert!(store.is_registered(STD_ID));
+    }
+
+    #[test]
+    fn add_std_defaults_to_the_builtin_compiler() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        if crate::compiler::resolve(&Config::default().compiler).is_err() {
+            return; // 組み込み既定のコンパイラが無い環境ではスキップ
+        }
+
+        add_std(&store, None).unwrap();
+
+        assert!(store.is_registered(STD_ID));
     }
 
     #[test]
@@ -322,6 +354,14 @@ mod tests {
     }
 
     #[test]
+    fn update_all_with_no_libraries_is_a_no_op() {
+        // 全件更新は登録ゼロでもエラーにせず、案内だけ出して正常終了する。
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        update(&store, None, None).unwrap();
+    }
+
+    #[test]
     fn list_and_show_tolerate_outdated_schema() {
         let local = TempDir::new().unwrap();
         let store = store_in(&local);
@@ -356,5 +396,33 @@ mod tests {
         let local = TempDir::new().unwrap();
         let store = store_in(&local);
         assert!(show(&store, "lib", false).is_err());
+    }
+
+    #[test]
+    fn show_prints_the_std_registration() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        write_std_registration(&store, vec![PathBuf::from("/usr/bin/g++")]);
+
+        show(&store, STD_ID, false).unwrap();
+        show(&store, STD_ID, true).unwrap();
+    }
+
+    #[test]
+    fn show_verbose_lists_implementation_targets() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        // クラス外の修飾付き定義 (`fps::shrink`) から実装先 `fps` が抽出されるソースを登録する。
+        let source = source_with(&[("fps.hpp", "struct fps {};\nvoid fps::shrink() {}\n")]);
+        add(&store, "fps-lib", source.path()).unwrap();
+
+        // verbose 表示の Implements 分岐が空リストで素通りしないことを、前提ごと確かめる。
+        let tags = Tags::load(&store.tags_json("fps-lib").unwrap()).unwrap();
+        let TagsKind::Library { implements, .. } = &tags.kind else {
+            panic!("非 std ライブラリは Library を持つべき");
+        };
+        assert!(!implements.is_empty(), "実装先が抽出される前提のソース");
+
+        show(&store, "fps-lib", true).unwrap();
     }
 }

--- a/src/commands/library.rs
+++ b/src/commands/library.rs
@@ -325,7 +325,7 @@ mod tests {
         update(&store, Some("lib"), Some(moved.path())).unwrap();
 
         let tags = Tags::load(&store.tags_json("lib").unwrap()).unwrap();
-        assert_eq!(tags.path, moved.path().canonicalize().unwrap());
+        assert_eq!(tags.path, dunce::canonicalize(moved.path()).unwrap());
         assert!(store.dummy_dir("lib").unwrap().join("b.hpp").is_file());
         assert!(!store.dummy_dir("lib").unwrap().join("a.hpp").is_file());
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -107,7 +107,10 @@ fn parse_search_dirs(verbose_output: &str) -> Vec<PathBuf> {
         .take_while(|line| !line.contains("End of search list."))
         .filter_map(|line| {
             let dir = PathBuf::from(line.trim());
-            dir.is_dir().then(|| dir.canonicalize().ok()).flatten()
+            // dunce 版 canonicalize で Windows の verbatim パス化を避ける (registry 側の解決と同じ規則)。
+            dir.is_dir()
+                .then(|| dunce::canonicalize(&dir).ok())
+                .flatten()
         })
         .collect()
 }
@@ -212,10 +215,10 @@ mod tests {
             End of search list.\n\
             trailing junk\n";
         // 実在する dir のみ realpath 化される。"." はカレントなので拾われる。
-        // 期待値も同じく canonicalize する: Windows の verbatim パス (`\\?\`) や macOS の
-        // symlink (/tmp→/private/tmp) で表記が分岐するため、関数と同じ正規化を通して比較する。
+        // 期待値も関数と同じ正規化 (dunce) を通して比較する: macOS の symlink (/tmp→/private/tmp)
+        // などで素のパスとは表記が分岐するため。
         let dirs = parse_search_dirs(verbose);
-        assert_eq!(dirs, vec![Path::new(".").canonicalize().unwrap()]);
+        assert_eq!(dirs, vec![dunce::canonicalize(Path::new(".")).unwrap()]);
     }
 
     #[cfg(unix)]
@@ -236,7 +239,7 @@ mod tests {
 
         assert_eq!(
             system_includes(&cc).unwrap(),
-            vec![include_dir.canonicalize().unwrap()]
+            vec![dunce::canonicalize(&include_dir).unwrap()]
         );
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -27,10 +27,8 @@ pub fn resolve(compiler: &Path) -> Result<PathBuf> {
                 compiler.display()
             )
         })?;
-        if !absolute.is_file() {
-            bail!("compiler {} not found", compiler.display());
-        }
-        absolute
+        existing_executable(absolute)
+            .ok_or_else(|| anyhow!("compiler {} not found", compiler.display()))?
     } else {
         let path_var = std::env::var_os("PATH").unwrap_or_default();
         find_in_path(compiler, &path_var)
@@ -47,9 +45,23 @@ pub fn resolve(compiler: &Path) -> Result<PathBuf> {
 
 /// `PATH` の各ディレクトリから `name` の実行ファイルを探し、最初に見つかったパスを返す。
 fn find_in_path(name: &Path, path_var: &OsStr) -> Option<PathBuf> {
-    std::env::split_paths(path_var)
-        .map(|dir| dir.join(name))
-        .find(|candidate| candidate.is_file())
+    std::env::split_paths(path_var).find_map(|dir| existing_executable(dir.join(name)))
+}
+
+/// `candidate` に実在する実行ファイルを返す。Windows では実体が `g++.exe` なので、拡張子なしの
+/// 指定に `.exe` を補った形も探す (`Command` がプロセス起動時に行う補完と同じ規則に揃える)。
+fn existing_executable(candidate: PathBuf) -> Option<PathBuf> {
+    if candidate.is_file() {
+        return Some(candidate);
+    }
+    #[cfg(windows)]
+    if candidate.extension().is_none() {
+        let with_exe = candidate.with_extension("exe");
+        if with_exe.is_file() {
+            return Some(with_exe);
+        }
+    }
+    None
 }
 
 /// コンパイラのシステム include パス一覧を検出する。
@@ -177,6 +189,17 @@ mod tests {
             find_in_path(Path::new("nonexistent-cc"), temp.path().as_os_str()),
             None
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn finds_bare_name_with_exe_extension_on_windows() {
+        // PATH 上の実体は `g++.exe` のように拡張子付き。拡張子なしの指定でも見つかるべき。
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("mycc.exe"), "").unwrap();
+
+        let found = find_in_path(Path::new("mycc"), temp.path().as_os_str());
+        assert_eq!(found, Some(temp.path().join("mycc.exe")));
     }
 
     #[test]

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -100,6 +100,25 @@ fn parse_search_dirs(verbose_output: &str) -> Vec<PathBuf> {
         .collect()
 }
 
+/// テスト用の偽コンパイラ生成。コンパイラ起動を伴う処理を、実コンパイラ無しで決定的にテスト
+/// するための共有補助。依存を内向きに保つため終端の本モジュールが持ち、`library` 側のテスト補助
+/// ([`crate::library::testutil`]) はこれを再輸出して使う。
+#[cfg(test)]
+pub mod testutil {
+    #[cfg(unix)]
+    use std::path::{Path, PathBuf};
+
+    /// 実行可能な偽コンパイラスクリプトを作る。`-v` の出力や終了コードを自由に偽装できる。
+    #[cfg(unix)]
+    pub fn fake_compiler(dir: &Path, body: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join("fake-cc");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,6 +126,9 @@ mod tests {
     use std::fs;
 
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use super::testutil::fake_compiler;
 
     #[test]
     fn resolves_path_with_separator_to_absolute() {
@@ -171,5 +193,69 @@ mod tests {
         // symlink (/tmp→/private/tmp) で表記が分岐するため、関数と同じ正規化を通して比較する。
         let dirs = parse_search_dirs(verbose);
         assert_eq!(dirs, vec![Path::new(".").canonicalize().unwrap()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn system_includes_parses_the_verbose_search_list() {
+        let temp = TempDir::new().unwrap();
+        let include_dir = temp.path().join("include");
+        fs::create_dir(&include_dir).unwrap();
+        let cc = fake_compiler(
+            temp.path(),
+            &format!(
+                "echo '#include <...> search starts here:' >&2\n\
+                 echo ' {}' >&2\n\
+                 echo 'End of search list.' >&2",
+                include_dir.display()
+            ),
+        );
+
+        assert_eq!(
+            system_includes(&cc).unwrap(),
+            vec![include_dir.canonicalize().unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn system_includes_reports_compiler_failure_with_its_stderr() {
+        let temp = TempDir::new().unwrap();
+        let cc = fake_compiler(temp.path(), "echo 'unsupported option' >&2\nexit 1");
+
+        let err = system_includes(&cc).unwrap_err().to_string();
+        assert!(
+            err.contains("failed to detect the system include paths"),
+            "{err}"
+        );
+        assert!(
+            err.contains("unsupported option"),
+            "原因特定のためコンパイラの標準エラーを含めるべき: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn system_includes_requires_a_nonempty_search_list() {
+        // 正常終了しても探索リストが空なら、後段で壊れる前にここで失敗する (フェイルファスト)。
+        let temp = TempDir::new().unwrap();
+        let cc = fake_compiler(
+            temp.path(),
+            "echo '#include <...> search starts here:' >&2\necho 'End of search list.' >&2",
+        );
+
+        let err = system_includes(&cc).unwrap_err().to_string();
+        assert!(
+            err.contains("could not detect any system include paths"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn system_includes_reports_launch_failure() {
+        // ディレクトリは実行できないため、プロセス起動自体が OS エラーになる経路を通す。
+        let temp = TempDir::new().unwrap();
+        let err = system_includes(temp.path()).unwrap_err().to_string();
+        assert!(err.contains("failed to launch compiler"), "{err}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,12 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn resolve_rejects_an_empty_start_path() {
+        // 空パスは絶対パス化できず探索起点が定まらないため、文脈付きで失敗する。
+        assert!(resolve(Path::new("")).is_err());
+    }
+
+    #[test]
     fn omitted_fields_fall_back_to_builtin_defaults() {
         let raw: RawConfig = toml::from_str("[bundle]\nembed = true\n").unwrap();
         let config: Config = raw.into();

--- a/src/fs/relpath.rs
+++ b/src/fs/relpath.rs
@@ -22,3 +22,18 @@ pub fn to_slash(relative: &Path) -> Result<String> {
     }
     Ok(parts.join("/"))
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn rejects_non_utf8_names() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::Path;
+
+        // 非 UTF-8 のファイル名は #include パスにも tags.json のキーにもなれないため弾く。
+        let relative = Path::new(OsStr::from_bytes(b"lib/\xff.hpp"));
+        assert!(super::to_slash(relative).is_err());
+    }
+}

--- a/src/library/dummy.rs
+++ b/src/library/dummy.rs
@@ -53,6 +53,19 @@ mod tests {
     }
 
     #[test]
+    fn reports_failure_when_the_dummy_parent_cannot_be_created() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        write_file(&source, "sub/a.hpp", "int a;");
+        let dummy = temp.path().join("dummy");
+        fs::create_dir_all(&dummy).unwrap();
+        // 親ディレクトリになるべき位置に既にファイルがあると、ダミーの書き出しに失敗する。
+        fs::write(dummy.join("sub"), "").unwrap();
+
+        assert!(generate(&source, &dummy).is_err());
+    }
+
+    #[test]
     fn mirrors_directory_structure_into_dummy_root() {
         let temp = TempDir::new().unwrap();
         let source = temp.path().join("source");

--- a/src/library/local.rs
+++ b/src/library/local.rs
@@ -210,7 +210,11 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let store = LocalStore::with_root(temp.path());
         register(&store, "lib");
-        fs::create_dir_all(store.libraries_dir().join(OsStr::from_bytes(b"\xff"))).unwrap();
+        // APFS (macOS) などは不正な UTF-8 のファイル名自体を作らせないため、作れた場合のみ検証する。
+        if fs::create_dir_all(store.libraries_dir().join(OsStr::from_bytes(b"\xff"))).is_err() {
+            eprintln!("skipped: このファイルシステムは非 UTF-8 のファイル名を作れない");
+            return;
+        }
 
         assert_eq!(store.library_ids().unwrap(), vec!["lib"]);
     }

--- a/src/library/local.rs
+++ b/src/library/local.rs
@@ -47,7 +47,11 @@ impl LocalStore {
     /// (Windows/macOS の `dirs` は OS 標準の API を使う) ため、テストの隔離や置き場所の変更に
     /// 全 OS 共通で使える上書き手段として持つ。
     pub fn discover() -> Result<Self> {
-        if let Some(data_home) = std::env::var_os("RISUNDLE_DATA_HOME") {
+        // 空文字列は未設定と同義に扱う (XDG Base Directory の慣例)。空のまま通すと相対パスになり、
+        // カレントディレクトリ配下へ意図せず読み書きしてしまう。
+        if let Some(data_home) = std::env::var_os("RISUNDLE_DATA_HOME")
+            && !data_home.is_empty()
+        {
             return Ok(Self::with_root(
                 PathBuf::from(data_home).join(Self::APP_DIR),
             ));

--- a/src/library/local.rs
+++ b/src/library/local.rs
@@ -170,4 +170,38 @@ mod tests {
         assert!(store.is_registered("std"));
         assert!(!store.is_registered("incomplete"));
     }
+
+    #[test]
+    fn library_ids_reports_an_unreadable_libraries_dir() {
+        // NotFound (未作成 = 登録ゼロ) 以外の読み取りエラーは握り潰さず文脈付きで返す。
+        let temp = TempDir::new().unwrap();
+        let store = LocalStore::with_root(temp.path());
+        fs::write(store.libraries_dir(), "").unwrap(); // ディレクトリの位置にファイル
+
+        assert!(store.library_ids().is_err());
+    }
+
+    #[test]
+    fn library_ids_skips_stray_files() {
+        let temp = TempDir::new().unwrap();
+        let store = LocalStore::with_root(temp.path());
+        register(&store, "lib");
+        fs::write(store.libraries_dir().join("README.txt"), "").unwrap();
+
+        assert_eq!(store.library_ids().unwrap(), vec!["lib"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn library_ids_skips_non_utf8_names() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp = TempDir::new().unwrap();
+        let store = LocalStore::with_root(temp.path());
+        register(&store, "lib");
+        fs::create_dir_all(store.libraries_dir().join(OsStr::from_bytes(b"\xff"))).unwrap();
+
+        assert_eq!(store.library_ids().unwrap(), vec!["lib"]);
+    }
 }

--- a/src/library/local.rs
+++ b/src/library/local.rs
@@ -41,7 +41,17 @@ impl LocalStore {
     const DUMMY_DIR: &'static str = "dummy";
 
     /// OS 標準のデータディレクトリから `$LOCAL` を解決する。
+    ///
+    /// `RISUNDLE_DATA_HOME` が設定されていればそちらを優先する (意味は `XDG_DATA_HOME` と同じで、
+    /// その配下の `risundle` が `$LOCAL` になる)。`XDG_DATA_HOME` は Linux でしか効かない
+    /// (Windows/macOS の `dirs` は OS 標準の API を使う) ため、テストの隔離や置き場所の変更に
+    /// 全 OS 共通で使える上書き手段として持つ。
     pub fn discover() -> Result<Self> {
+        if let Some(data_home) = std::env::var_os("RISUNDLE_DATA_HOME") {
+            return Ok(Self::with_root(
+                PathBuf::from(data_home).join(Self::APP_DIR),
+            ));
+        }
         let data_local =
             dirs::data_local_dir().context("could not determine the OS local data directory")?;
         Ok(Self::with_root(data_local.join(Self::APP_DIR)))

--- a/src/library/registry.rs
+++ b/src/library/registry.rs
@@ -366,6 +366,100 @@ mod tests {
     }
 
     #[test]
+    fn reregister_rejects_a_path_for_std() {
+        // std の実体はコンパイラから検出するもので、パス指定は意味を持たないため弾く。
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let roots = source_with(&[("vector", "// std header")]);
+        register_std(
+            &store,
+            &[(
+                PathBuf::from("/usr/bin/g++"),
+                vec![roots.path().to_path_buf()],
+            )],
+        )
+        .unwrap();
+
+        let err = reregister(&store, STD_ID, Some(Path::new("/tmp")))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cannot be specified for the standard library"),
+            "{err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reregister_rediscovers_std_from_the_stored_compilers() {
+        use crate::library::testutil::fake_compiler_with_includes;
+
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let scripts = TempDir::new().unwrap();
+        let include = source_with(&[("vector", "// std header")]);
+        let cc = fake_compiler_with_includes(scripts.path(), include.path());
+        register_std(&store, &[(cc.clone(), vec![include.path().to_path_buf()])]).unwrap();
+
+        // ダミーツリーを消し、path 無しの再登録が保存済みコンパイラから再検出することを確かめる。
+        fs::remove_dir_all(store.dummy_dir(STD_ID).unwrap()).unwrap();
+        reregister(&store, STD_ID, None).unwrap();
+
+        assert!(store.dummy_dir(STD_ID).unwrap().join("vector").is_file());
+        let tags = Tags::load(&store.tags_json(STD_ID).unwrap()).unwrap();
+        assert_eq!(
+            tags.kind,
+            TagsKind::Std {
+                compilers: vec![cc]
+            }
+        );
+    }
+
+    #[test]
+    fn auto_setup_std_skips_when_already_registered() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        let roots = source_with(&[("vector", "// std header")]);
+        let marker = PathBuf::from("/opt/previous-g++");
+        register_std(
+            &store,
+            &[(marker.clone(), vec![roots.path().to_path_buf()])],
+        )
+        .unwrap();
+
+        auto_setup_std(&store).unwrap();
+
+        // 実コンパイラの有無に関わらず、既存の登録は上書きされない。
+        let tags = Tags::load(&store.tags_json(STD_ID).unwrap()).unwrap();
+        assert_eq!(
+            tags.kind,
+            TagsKind::Std {
+                compilers: vec![marker]
+            }
+        );
+    }
+
+    #[test]
+    fn auto_setup_std_registers_detected_compilers() {
+        let local = TempDir::new().unwrap();
+        let store = store_in(&local);
+        if compiler::resolve(Path::new("g++")).is_err()
+            && compiler::resolve(Path::new("clang++")).is_err()
+        {
+            return; // 候補コンパイラが無い環境ではスキップ
+        }
+
+        auto_setup_std(&store).unwrap();
+
+        assert!(store.is_registered(STD_ID));
+        let tags = Tags::load(&store.tags_json(STD_ID).unwrap()).unwrap();
+        let TagsKind::Std { compilers } = tags.kind else {
+            panic!("std は Std 種別で登録されるべき");
+        };
+        assert!(!compilers.is_empty());
+    }
+
+    #[test]
     fn add_std_keeps_the_compiler_set_from_an_older_schema() {
         let local = TempDir::new().unwrap();
         let store = store_in(&local);

--- a/src/library/registry.rs
+++ b/src/library/registry.rs
@@ -163,10 +163,14 @@ fn recreate_library_dir(store: &LocalStore, id: &str) -> Result<()> {
         .with_context(|| format!("failed to create {}", library_dir.display()))
 }
 
-/// インクルードパスを絶対パスへ解決する。`canonicalize` は存在しないパスでエラーになるため、
+/// インクルードパスを絶対パスへ解決する。canonicalize は存在しないパスでエラーになるため、
 /// 絶対パス化と存在確認を兼ねる。
+///
+/// `dunce::canonicalize` を使うのは Windows 対策。`std` の canonicalize は verbatim パス
+/// (`\\?\C:\...`) を返し、これを `-I` に渡されたコンパイラはヘッダーを解決できない。
+/// バンドル側の canonicalize も、突き合わせがずれないよう同じ理由で dunce に統一している。
 pub fn resolve_source_root(path: &Path) -> Result<PathBuf> {
-    path.canonicalize()
+    dunce::canonicalize(path)
         .with_context(|| format!("failed to resolve include path {}", path.display()))
 }
 

--- a/src/library/tags.rs
+++ b/src/library/tags.rs
@@ -203,6 +203,21 @@ mod tests {
 
     use tempfile::TempDir;
 
+    #[test]
+    fn kind_label_distinguishes_std_and_library() {
+        let std_reg = Registration {
+            path: PathBuf::from("/usr/include"),
+            compilers: Some(vec![PathBuf::from("/usr/bin/g++")]),
+        };
+        assert_eq!(std_reg.kind_label(), "std");
+
+        let library_reg = Registration {
+            path: PathBuf::from("/home/user/lib"),
+            compilers: None,
+        };
+        assert_eq!(library_reg.kind_label(), "library");
+    }
+
     fn library_tags() -> Tags {
         Tags {
             path: PathBuf::from("/usr/local/include"),

--- a/src/library/testutil.rs
+++ b/src/library/testutil.rs
@@ -3,12 +3,14 @@
 
 use std::fs;
 #[cfg(unix)]
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
 use tempfile::TempDir;
 
 use crate::library::local::LocalStore;
-use crate::library::tags::Tags;
+use crate::library::registry::STD_ID;
+use crate::library::tags::{Tags, TagsKind};
 
 pub fn source_with(files: &[(&str, &str)]) -> TempDir {
     let temp = TempDir::new().unwrap();
@@ -41,6 +43,17 @@ pub fn fake_compiler_with_includes(dir: &Path, include_dir: &Path) -> PathBuf {
             include_dir.display()
         ),
     )
+}
+
+/// std の登録を `tags.json` 直書きで用意する。コンパイラを起動せずに std がらみの分岐を検証するため。
+pub fn write_std_registration(store: &LocalStore, compilers: Vec<PathBuf>) {
+    fs::create_dir_all(store.library_dir(STD_ID).unwrap()).unwrap();
+    Tags {
+        path: PathBuf::from("/usr/include/c++/14"),
+        kind: TagsKind::Std { compilers },
+    }
+    .save(&store.tags_json(STD_ID).unwrap())
+    .unwrap();
 }
 
 /// 登録済みライブラリの `tags.json` を、現行と異なる `schema_version` に書き換える (移行の検証用)。

--- a/src/library/testutil.rs
+++ b/src/library/testutil.rs
@@ -1,7 +1,9 @@
-//! 登録まわりのテスト補助。registry (登録処理) と commands/library (受け口) の両テストが、
-//! 同じ手順でソースツリーとストアを組み立てられるよう共有する。
+//! 登録まわりのテスト補助。registry (登録処理) と commands (受け口) の両テストが、
+//! 同じ手順でソースツリー・ストア・偽コンパイラを組み立てられるよう共有する。
 
 use std::fs;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
@@ -20,6 +22,25 @@ pub fn source_with(files: &[(&str, &str)]) -> TempDir {
 
 pub fn store_in(local: &TempDir) -> LocalStore {
     LocalStore::with_root(local.path())
+}
+
+// 偽コンパイラの生成は、依存の終端である compiler 側の補助を再輸出する (library → compiler は
+// 許された辺で、逆向きの重複定義を持たずに済む)。
+#[cfg(unix)]
+pub use crate::compiler::testutil::fake_compiler;
+
+/// `-v` の探索リストに `include_dir` だけを出す偽コンパイラを作る (std 登録の検出経路用)。
+#[cfg(unix)]
+pub fn fake_compiler_with_includes(dir: &Path, include_dir: &Path) -> PathBuf {
+    fake_compiler(
+        dir,
+        &format!(
+            "echo '#include <...> search starts here:' >&2\n\
+             echo ' {}' >&2\n\
+             echo 'End of search list.' >&2",
+            include_dir.display()
+        ),
+    )
 }
 
 /// 登録済みライブラリの `tags.json` を、現行と異なる `schema_version` に書き換える (移行の検証用)。

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -210,7 +210,7 @@ fn used_and_unused_library() -> Sandbox {
 /// sandbox 内で `risundle <args> main.cpp` を実行し、標準出力を返す。
 fn run_bundle(sandbox: &Sandbox, args: &[&str]) -> String {
     let output = sandbox
-        .risundle()
+        .bundle_command()
         .args(args)
         .arg("main.cpp")
         .output()
@@ -407,7 +407,7 @@ fn bundle_passes_options_after_double_dash_to_compiler() {
 
     // -D が届かなければ #error でプリプロセスごと失敗するので、成功 = 受け渡しの証明。
     let output = sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "main.cpp", "--", "-DRISUNDLE_TEST_ANSWER=0"])
         .output()
         .expect("run bundle");
@@ -430,7 +430,7 @@ fn embed_includes_original_source_as_comment() {
     sandbox.write("main.cpp", main);
 
     sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "-e", "main.cpp"])
         .assert()
         .success()
@@ -442,7 +442,7 @@ fn embed_includes_original_source_as_comment() {
 fn bundle_fails_for_missing_input_file() {
     let sandbox = Sandbox::new();
     sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "ghost.cpp"])
         .assert()
         .failure();
@@ -466,7 +466,7 @@ fn bundle_detects_library_changes_unless_verification_is_bypassed() {
     sandbox.write("main.cpp", "int main() { return 0; }\n");
 
     sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "main.cpp"])
         .assert()
         .failure()
@@ -474,14 +474,14 @@ fn bundle_detects_library_changes_unless_verification_is_bypassed() {
 
     // --no-check ならハッシュ検証を飛ばして通る。
     sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "--no-check", "main.cpp"])
         .assert()
         .success();
 
     // --no-tree-shaking は識別子タグを使わないため、検証自体が不要になり通る。
     sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "--no-tree-shaking", "main.cpp"])
         .assert()
         .success();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,19 +1,57 @@
 //! E2E テストの共通基盤。各テストを独立した `$LOCAL` (`XDG_DATA_HOME`) と作業ディレクトリへ隔離し、
 //! 実バイナリを CLI 経由で起動する。内部構造に踏み込まず、ユーザーが叩くコマンドだけを通すことで、
 //! 実装変更に強い E2E を保つ。
+//!
+//! テスト対象のコンパイラは [`test_compiler`] (`RISUNDLE_TEST_COMPILER`、既定 g++) で決まり、
+//! std 登録・バンドル・検証コンパイルの全工程を同じコンパイラで一貫して通す。コンパイラや OS の
+//! 掛け算は CI のマトリクスに任せ、1 プロセスは 1 コンパイラの世界に保つ。
 
 #![allow(dead_code)] // 各テストファイルがヘルパーの一部だけを使うため。
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 use assert_cmd::cargo::CommandCargoExt;
 use tempfile::TempDir;
 
+/// テスト対象のコンパイラ。`RISUNDLE_TEST_COMPILER` で切り替え、省略時は g++。
+pub fn test_compiler() -> &'static str {
+    static COMPILER: OnceLock<String> = OnceLock::new();
+    COMPILER.get_or_init(|| {
+        std::env::var("RISUNDLE_TEST_COMPILER").unwrap_or_else(|_| "g++".to_owned())
+    })
+}
+
+/// テスト対象コンパイラが `<bits/stdc++.h>` を解決できるかを、プロセス内で 1 度だけ調べる。
+///
+/// このヘッダーは libstdc++ (GCC 系) 専用で、libc++ (macOS の Apple clang など) には存在しない。
+/// 依存するテストはこれで自己スキップする。`cfg` でなく実測にするのは、環境の実態 (macOS でも
+/// GCC を入れていれば走る、など) に従うため。
+pub fn supports_bits_stdcxx() -> bool {
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        let mut probe = Command::new(test_compiler())
+            .args(["-x", "c++", "-E", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("launch the test compiler");
+        probe
+            .stdin
+            .take()
+            .expect("open the probe's stdin")
+            .write_all(b"#include <bits/stdc++.h>\n")
+            .expect("write the probe source");
+        probe.wait().expect("wait for the probe").success()
+    })
+}
+
 /// 実 `add-std` を一度だけ行い、その結果をテンプレートとして保持する。
 ///
-/// `add-std` は g++ のシステム include 全体を走査するため数秒かかる。テストごとに繰り返すと
+/// `add-std` はコンパイラのシステム include 全体を走査するため数秒かかる。テストごとに繰り返すと
 /// 総時間が嵩むので、プロセス内で 1 回だけ実行し、各サンドボックスへは複製して配る。
 fn std_template() -> &'static Path {
     static TEMPLATE: OnceLock<TempDir> = OnceLock::new();
@@ -22,13 +60,14 @@ fn std_template() -> &'static Path {
             let data = TempDir::new().expect("create std template dir");
             let status = Command::cargo_bin("risundle")
                 .expect("locate risundle binary")
-                .args(["library", "add-std"])
+                .args(["library", "add-std", test_compiler()])
                 .env("XDG_DATA_HOME", data.path())
                 .status()
                 .expect("run library add-std");
             assert!(
                 status.success(),
-                "`risundle library add-std` に失敗 (E2E には g++ が必要)"
+                "`risundle library add-std {}` に失敗 (E2E にはテスト対象のコンパイラが必要)",
+                test_compiler()
             );
             data
         })
@@ -77,6 +116,14 @@ impl Sandbox {
         command
     }
 
+    /// バンドル用の risundle コマンド。テスト対象のコンパイラを `--compiler` で明示済みなので、
+    /// 呼び出し側は既定コンパイラ (g++) 前提を持ち込まずに済む。
+    pub fn bundle_command(&self) -> Command {
+        let mut command = self.risundle();
+        command.args(["--compiler", test_compiler()]);
+        command
+    }
+
     /// 作業ディレクトリにファイルを書き、その絶対パスを返す。
     pub fn write(&self, relative: &str, content: &str) -> PathBuf {
         let path = self.work.path().join(relative);
@@ -98,7 +145,7 @@ impl Default for Sandbox {
     }
 }
 
-/// バンドル済みソースを g++ でコンパイル・実行し、標準出力を返す。
+/// バンドル済みソースをテスト対象のコンパイラでコンパイル・実行し、標準出力を返す。
 ///
 /// コンパイルが通ること自体が「必要なヘッダーが過不足なく残った」ことの証明になる。
 pub fn compile_and_run(sandbox: &Sandbox, bundled: &str) -> String {
@@ -106,12 +153,12 @@ pub fn compile_and_run(sandbox: &Sandbox, bundled: &str) -> String {
     std::fs::write(&source, bundled).expect("write bundled source");
     let binary = sandbox.work_dir().join("bundled.out");
 
-    let compiled = Command::new("g++")
+    let compiled = Command::new(test_compiler())
         .args(["-std=c++17", "-O0", "-o"])
         .arg(&binary)
         .arg(&source)
         .output()
-        .expect("run g++");
+        .expect("run the test compiler");
     assert!(
         compiled.status.success(),
         "バンドル結果のコンパイルに失敗:\n{}",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
-//! E2E テストの共通基盤。各テストを独立した `$LOCAL` (`XDG_DATA_HOME`) と作業ディレクトリへ隔離し、
-//! 実バイナリを CLI 経由で起動する。内部構造に踏み込まず、ユーザーが叩くコマンドだけを通すことで、
+//! E2E テストの共通基盤。各テストを独立した `$LOCAL` (`RISUNDLE_DATA_HOME`。`XDG_DATA_HOME` は
+//! Linux でしか効かないため全 OS 共通の上書きを使う) と作業ディレクトリへ隔離し、実バイナリを
+//! CLI 経由で起動する。内部構造に踏み込まず、ユーザーが叩くコマンドだけを通すことで、
 //! 実装変更に強い E2E を保つ。
 //!
 //! テスト対象のコンパイラは [`test_compiler`] (`RISUNDLE_TEST_COMPILER`、既定 g++) で決まり、
@@ -61,7 +62,7 @@ fn std_template() -> &'static Path {
             let status = Command::cargo_bin("risundle")
                 .expect("locate risundle binary")
                 .args(["library", "add-std", test_compiler()])
-                .env("XDG_DATA_HOME", data.path())
+                .env("RISUNDLE_DATA_HOME", data.path())
                 .status()
                 .expect("run library add-std");
             assert!(
@@ -107,11 +108,11 @@ impl Sandbox {
         }
     }
 
-    /// `XDG_DATA_HOME` と作業ディレクトリを束ねた risundle コマンドを返す。
+    /// `RISUNDLE_DATA_HOME` と作業ディレクトリを束ねた risundle コマンドを返す。
     pub fn risundle(&self) -> Command {
         let mut command = Command::cargo_bin("risundle").expect("locate risundle binary");
         command
-            .env("XDG_DATA_HOME", self.data.path())
+            .env("RISUNDLE_DATA_HOME", self.data.path())
             .current_dir(self.work.path());
         command
     }

--- a/tests/libraries.rs
+++ b/tests/libraries.rs
@@ -1,24 +1,26 @@
 //! 実ライブラリ E2E。submodule で取得した実際の競技プログラミングライブラリを登録し、それらを
-//! 使う小さなプログラムをバンドルして g++ でコンパイル・実行する。
+//! 使う小さなプログラムをバンドルして、テスト対象のコンパイラでコンパイル・実行する。
 //!
 //! コンパイルが通ることは「必要なヘッダーが削られていない」ことしか保証しない。余分なヘッダーが残っても
 //! `#pragma once` 等でコンパイルは通ってしまうからだ。そこで併せて、使ったデータ構造とは無関係な (だが
 //! ライブラリ内には実在する) シンボルがバンドルに混入していないことも確かめ、tree-shaking が実際に
 //! 効いていることを担保する。
 //!
-//! 前提: submodule が取得済みで g++ が利用可能であること (`git submodule update --init`)。
+//! 前提: submodule が取得済みで、テスト対象のコンパイラ (`RISUNDLE_TEST_COMPILER`、既定 g++) が
+//! 利用可能であること (`git submodule update --init`)。`<bits/stdc++.h>` に依存するライブラリの
+//! テストは、libc++ 環境 (macOS の Apple clang など) では自己スキップする。
 
 mod common;
 
 use std::path::Path;
 
 use assert_cmd::prelude::*;
-use common::{Sandbox, compile_and_run, fixture};
+use common::{Sandbox, compile_and_run, fixture, supports_bits_stdcxx};
 
 /// 維持指定する標準ライブラリ ID。
 const STD: &str = "std";
 
-/// バンドル結果。展開済みソースと、それを g++ でコンパイル・実行した標準出力を持つ。
+/// バンドル結果。展開済みソースと、それをテスト対象のコンパイラでコンパイル・実行した標準出力を持つ。
 struct Bundle {
     source: String,
     output: String,
@@ -55,7 +57,7 @@ fn bundle_with_library(lib_path: &Path, id: &str, source: &str) -> Bundle {
 
     sandbox.write("main.cpp", source);
     let output = sandbox
-        .risundle()
+        .bundle_command()
         .args(["-k", STD, "main.cpp"])
         .output()
         .expect("run bundle");
@@ -107,6 +109,11 @@ fn ac_library_keeps_only_the_structures_in_use() {
 
 #[test]
 fn nyaan_union_find_bundles_compiles_and_runs() {
+    // Nyaan's Library はヘッダー内部でも <bits/stdc++.h> を使うため、libstdc++ が前提。
+    if !supports_bits_stdcxx() {
+        eprintln!("skipped: テスト対象のコンパイラは <bits/stdc++.h> を提供しない");
+        return;
+    }
     let source = "#include <bits/stdc++.h>\nusing namespace std;\n\
         #include <data-structure/union-find.hpp>\n\
         int main() {\n\
@@ -122,6 +129,10 @@ fn nyaan_union_find_bundles_compiles_and_runs() {
 
 #[test]
 fn luzhiled_union_find_bundles_compiles_and_runs() {
+    if !supports_bits_stdcxx() {
+        eprintln!("skipped: テスト対象のコンパイラは <bits/stdc++.h> を提供しない");
+        return;
+    }
     let source = "#include <bits/stdc++.h>\nusing namespace std;\n\
         #include <structure/union-find/union-find.hpp>\n\
         int main() {\n\
@@ -137,6 +148,10 @@ fn luzhiled_union_find_bundles_compiles_and_runs() {
 
 #[test]
 fn kactl_union_find_bundles_compiles_and_runs() {
+    if !supports_bits_stdcxx() {
+        eprintln!("skipped: テスト対象のコンパイラは <bits/stdc++.h> を提供しない");
+        return;
+    }
     // KACTL のヘッダーは `vi` (= vector<int>) 等の typedef を利用側が用意する前提。
     let source = "#include <bits/stdc++.h>\nusing namespace std;\n\
         typedef vector<int> vi;\n\


### PR DESCRIPTION
Closes #39

## 概要

カバレッジレポートを基点にテストを強化し (#39)、あわせて E2E を「g++ と clang++ の 2 コンパイラ × Ubuntu / macOS / Windows の 3 OS」で回す体制を整えます。E2E を広げた結果として **Windows では risundle が事実上動いていなかった**ことが判明し、原因の製品バグ 4 件をまとめて修正しています。

## テストの追加 (カバレッジ 95.3% → 98.0%)

未カバー行を機能単位で洗い出し、単体テストを 29 件追加しました (162 → 191 件)。

- **偽コンパイラ fixture**: `-v` の出力や終了コードを自由に偽装できるシェルスクリプトの偽コンパイラを導入し、実コンパイラでは再現しにくい異常系を決定的にテスト。依存を内向きに保つため `compiler::testutil` (`#[cfg(test)]`) に置き、`library::testutil` が再輸出する
- **registry の大物**: 丸ごと未テストだった `auto_setup_std` (初回自動登録)、`reregister` の std 分岐 (`update std` の再検出・std への path 指定拒否)
- **受け口 (#42 からの宿題)**: コマンド層 `add-std` (明示コンパイラ / 組み込み既定)、show の std 表示、verbose の Implements 表示、全件 update の空ケース
- **commands/bundle の単体化**: `warn_std_compiler` 全 4 状態、`run_capturing` の失敗系 (非ゼロ終了・非 UTF-8 出力)、`display_origin` のフォールバック、`needed_headers` の短絡、`Settings::resolve` のマージ規則
- **小物のエラー・スキップ経路**: relpath 非 UTF-8、config 空パス、`kind_label`、dummy 親作成失敗、`library_ids` のエッジ 3 種

## E2E のクロスコンパイラ化

- テスト対象コンパイラを `RISUNDLE_TEST_COMPILER` (既定 g++) で切り替え、**add-std → バンドル → 検証コンパイルの 3 役を同一コンパイラで一貫して通す**。1 プロセス 1 コンパイラの世界を保ち、掛け算は CI マトリクスの責任とする
- `<bits/stdc++.h>` (libstdc++ 専用。Nyaan's Library はヘッダー内部でも使う) に依存するテストは、実際のコンパイラに probe して libc++ 環境では自己スキップ
- CI マトリクス: Ubuntu + g++ (coverage ジョブ)、Ubuntu + clang++、macOS ×2 + Apple clang、Windows + MinGW g++。macOS / Windows は従来の `--bins` のみからフルスイートへ昇格 (**macOS と Windows の E2E はこの PR が史上初**)
- MSVC は対象外 (README に明記済み。#37 の議論参照)。Windows の clang++ は MSVC の標準ライブラリと繋がる特殊構成のため初回スコープ外

## 掘り出された製品バグの修正 (4 件、いずれも Windows)

初の Windows E2E が段階的に検出したもので、CI を 4 巡して全て潰しました。

1. **`compiler::resolve` が `.exe` を知らない**: PATH 探索が `g++` という名前のファイルを探すため、実体が `g++.exe` の Windows では必ず失敗し、`add-std` が常に失敗していた。`Command` の起動規則に合わせて `.exe` を補って探索するよう修正
2. **ストアの上書き手段の欠如**: `XDG_DATA_HOME` は Linux でしか効かず (Windows/macOS の `dirs` は OS 標準 API を使う)、テストの隔離が Windows で破れていた。環境変数 **`RISUNDLE_DATA_HOME`** (意味は `XDG_DATA_HOME` と同じ・全 OS で有効) を新設し、spec に明記
3. **verbatim パスをコンパイラに渡していた**: `canonicalize` が Windows で返す `\\?\C:\...` を `-I` に渡されたコンパイラはヘッダーを解決できない。コンパイラへ渡る・突き合わせに使う canonicalize を [`dunce`](https://crates.io/crates/dunce) 版に統一 (Unix では従来と同一の結果)
4. **`-M` 出力の解析が Windows パスを壊す**: バックスラッシュを無差別にエスケープ扱いしていたため、MinGW g++ が書く `C:\Users\...` の区切りが食われてパスが崩壊 → 必要集合が空 = **使用ヘッダーまで全削除**という判定崩壊。復元するエスケープを make が実際に生成する `\ ` と `\#` に限定

## テスト

- 全 191 テスト (単体 169 + 結合 22) が g++ / clang++ の両方でローカル通過
- CI は OS × コンパイラの全マトリクスが green ([run 29112186838](https://github.com/TwoSquirrels/risundle/actions/runs/29112186838))
- `-M` 解析の Windows パス破壊など、各バグには再発防止の単体テストを付与

## 残タスク (スコープ外)

- Ubuntu + g++ 以外でのカバレッジ計測は不要と判断 (計測は coverage ジョブに一本化)
- Windows + clang++ の E2E は将来必要になったら検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring risbundle’s local data directory with `RISBUNDLE_DATA_HOME`.
  * Improved compiler detection across platforms, including Windows executable resolution.

* **Bug Fixes**
  * Fixed Windows path handling during dependency and header discovery.
  * Improved filesystem path handling for cross-platform bundling workflows.
  * Enhanced compiler error reporting and handling of invalid or missing paths.

* **Documentation**
  * Clarified installation requirements, including the need for a GCC-compatible C++ compiler.
  * Documented that MSVC is not supported and explained local cache storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->