### PR TITLE
E2E の偽コンパイラ起動が ETXTBSY でまれに落ちるのを修正

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -130,6 +130,34 @@ pub mod testutil {
         let path = dir.join("fake-cc");
         std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // 書いた直後のスクリプトは、起動がまれに ETXTBSY (Text file busy) で失敗する: 並列テストの
+        // 別スレッドが書き込み中に fork すると、複製された書き込み fd が子プロセスの exec まで
+        // 生き残るため (Linux の既知の競合)。そこで、起動できることを空実行で確かめてから返す。
+        // 一度起動できたなら書き込み fd はもう残っていないので、呼び出し側は安全に起動できる。
+        // ETXTBSY 以外の失敗は原因が別 (権限や形式の問題) なので、後段の分かりにくい失敗に
+        // 化けないようここで即座に落とす。
+        let mut busy_attempts = 0;
+        loop {
+            let probe = std::process::Command::new(&path)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+            match probe {
+                Ok(_) => break,
+                Err(err) if err.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    busy_attempts += 1;
+                    assert!(
+                        busy_attempts < 100,
+                        "偽コンパイラ {} が ETXTBSY のまま起動可能にならない",
+                        path.display()
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(err) => panic!("偽コンパイラ {} の起動確認に失敗: {err}", path.display()),
+            }
+        }
         path
     }
 }


### PR DESCRIPTION
## 概要

#45 のマージ直後、main の CI ([run 29114215644](https://github.com/TwoSquirrels/risundle/actions/runs/29114215644)) が `add_std_registers_via_the_requested_compiler` の `Text file busy` (ETXTBSY) で落ちた問題の修正です。テストのみの変更で、製品コードには触れません。

## 原因

#45 で導入した偽コンパイラは、テスト自身がスクリプトを書いてから起動します。並列テストの別スレッドが書き込み中に fork すると、複製された書き込み fd が子プロセスの exec まで生き残り、その間のスクリプト起動が ETXTBSY で失敗します (Linux の既知の競合)。タイミング依存のため、ブランチ CI の 5 巡は通過し、main の 1 巡目で初めて顕在化しました。PR と main で CI の構成差はありません。

## 修正

`fake_compiler` helper (全テストが共有する 1 箇所) で、スクリプトを書いた後に「起動できることを空実行で確かめてから返す」ようにしました。一度起動できれば書き込み fd はもう存在しないため、以降の呼び出し側の起動でこの競合は起こりません。判定は標準の `io::ErrorKind::ExecutableFileBusy` で行います。

## テスト

- フルスイート 3 回連続 green (競合は確率的なため反復で確認)・fmt・clippy クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
