### PR TITLE
複数宣言子 (`int x, y;`) の 2 個目以降の識別子取りこぼしを修正

### DIFF
--- a/src/library/identifiers.rs
+++ b/src/library/identifiers.rs
@@ -118,7 +118,9 @@ fn collect_definitions(
         return;
     }
     for field in ["name", "declarator"] {
-        if let Some(child) = node.child_by_field_name(field) {
+        let mut cursor = node.walk();
+        // `int x, y;` のように 1 宣言に宣言子は複数付き得るため、最初の 1 つでは足りない。
+        for child in node.children_by_field_name(field, &mut cursor) {
             collect_leaf(child, source, names, implements);
         }
     }
@@ -333,6 +335,16 @@ mod tests {
         // type フィールド内に直接書かれた型定義も、全子再帰で拾える。
         let names = names_in("struct X { int a; } var; enum E { Red } e;");
         for expected in ["X", "a", "var", "E", "Red", "e"] {
+            assert!(names.contains(&expected.to_owned()), "{expected} が漏れた");
+        }
+    }
+
+    #[test]
+    fn captures_all_declarators_in_one_declaration() {
+        // `int x, y;` の 2 個目以降も拾う (#41)。struct メンバのむき出しの field_identifier は
+        // ラッパーを持たず子再帰でも救われないため、declarator フィールドの全列挙だけが経路。
+        let names = names_in("struct S { int x, y; };\nstruct T { int a = 0, b = 0; };");
+        for expected in ["S", "x", "y", "T", "a", "b"] {
             assert!(names.contains(&expected.to_owned()), "{expected} が漏れた");
         }
     }


### PR DESCRIPTION
## 概要

`struct S { int x, y; };` のように 1 宣言に複数のメンバ宣言子を並べた場合、識別子抽出が 2 個目以降を取りこぼすバグ (#41) を修正する。「過剰検出は安全・取りこぼしだけが依存漏れ」という設計 invariant への違反だった。

## 変更内容

- `collect_definitions` の `child_by_field_name("declarator")` を `children_by_field_name("declarator", ..)` に変更し、全宣言子を舐めるようにした (`name` フィールドも同一ループのため統一的に複数対応)
- テスト `captures_all_declarators_in_one_declaration` を追加 (むき出し `int x, y;` と初期化子付き `int a = 0, b = 0;` の両方)

## 検証

- 全テスト・clippy 通過
- Issue 記載の再現例 (前方宣言のみの factory ヘッダー + `auto` 受け + 落ちる側の `y` だけ参照) を実際にバンドルし、main では prune されていた `type.hpp` がバンドルに残り、コンパイル・実行まで通ることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier detection for declarations containing multiple declarators, such as `int x, y;`.
  * Ensures all declared identifiers are recognized in class and struct members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->