### PR TITLE
リリースノートが 4 つ重複生成されるのを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,27 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --locked
 
+  # リリースの作成とノート生成はここで 1 回だけ行う。binaries の matrix 側に持たせると、
+  # ジョブの数だけノートが重複して追記される (#52)。
+  release:
+    name: create GitHub release
+    needs: [validate, publish]
+    if: needs.validate.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # 部分失敗後の re-run でも通るよう、既存リリースがあれば作成をスキップする。
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 ||
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --verify-tag --generate-notes
+
   binaries:
     name: binary (${{ matrix.target }})
-    needs: [validate, publish]
+    needs: [validate, release]
     if: needs.validate.outputs.release == 'true'
     runs-on: ${{ matrix.os }}
     permissions:
@@ -119,8 +137,9 @@ jobs:
           Compress-Archive -Path "target/${{ matrix.target }}/release/risundle.exe" -DestinationPath "$name.zip"
           "ASSET=$name.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      # --clobber は re-run 時の同名アセットの置き換え用。
       - name: Upload to release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          files: ${{ env.ASSET }}
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: gh release upload "$GITHUB_REF_NAME" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
Fix #52

## 原因

`binaries` ジョブの matrix (4 target) がそれぞれ `softprops/action-gh-release` を `generate_release_notes: true` 付きで呼んでいたため、既存リリースへのノート追記がジョブの数だけ発生していました (Issue のコメントの推測どおり、アセットの数 = matrix の数だけ重複)。

## 変更内容

- リリースの作成とノート生成を、専用の `release` ジョブ (publish の後・binaries の前) で 1 回だけ行うようにした
- matrix 側の各ジョブは `gh release upload` によるアセットのアップロードのみに変更 (`softprops/action-gh-release` への依存を削除。gh CLI は全 runner に同梱)
- 部分失敗後の re-run 対策として、リリース作成は既存チェック付き、アップロードは `--clobber` 付き

## 留意点

- 従来と異なり、リリース (ノート付き) はバイナリのビルド完了前に公開され、アセットは数分遅れてぶら下がります。crates.io への publish 成功後なのでリリース自体は確定しており、許容としました。
- workflow はタグ push でしか走らないため、実地検証は次のリリース時になります (YAML 構文と gh の引数は確認済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved release automation to create each GitHub release only once.
  * Release assets are uploaded after the release is available.
  * Re-running a release safely replaces existing assets with the same name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->