### PR TITLE
Windows CI のテストを Defender のスキャン対象から外して高速化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,22 @@ jobs:
     env:
       RISUNDLE_TEST_COMPILER: ${{ matrix.compiler }}
     steps:
+      # Windows では std ダミーツリー生成 (数千個の小ファイル書き込み) が Defender の
+      # リアルタイムスキャンに捕まり、テストが桁違いに遅くなる (#58)。使い捨てランナーなので、
+      # ワークスペース・一時ディレクトリ・cargo キャッシュをスキャン対象から外す。
+      # ランナーの TEMP は 8.3 短縮形 (RUNNER~1) で入っており実パスと照合されない恐れがあるため、
+      # 同じ場所を指す長い表記 (LOCALAPPDATA\Temp) も並べて除外する。
+      - name: Exclude build directories from Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          Add-MpPreference -ExclusionPath @(
+            $env:GITHUB_WORKSPACE,
+            $env:RUNNER_TEMP,
+            $env:TEMP,
+            (Join-Path $env:LOCALAPPDATA 'Temp'),
+            (Join-Path $env:USERPROFILE '.cargo')
+          )
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       # 同じ場所を指す長い表記 (LOCALAPPDATA\Temp) も並べて除外する。
       - name: Exclude build directories from Windows Defender
         if: runner.os == 'Windows'
+        continue-on-error: true
         shell: powershell
         run: |
           Add-MpPreference -ExclusionPath @(


### PR DESCRIPTION
Resolves #58

## 概要

Windows の test ジョブに、Windows Defender の除外パスを追加するステップを足します。#58 の対策第一候補 (効き目順 1 番) の実装です。

## 背景

test (windows-latest, g++) だけ毎回数分かかり、支配的なのは std ダミーツリー生成 (数千個の小ファイル書き込み) が Defender のリアルタイムスキャンに捕まることでした (詳細は #58 の分析を参照)。使い捨てランナーなので、スキャン対象から書き込み先を外します。

## 変更内容

- test ジョブの先頭 (checkout・キャッシュ復元より前) に、Windows 限定の `Add-MpPreference -ExclusionPath` ステップを追加。
- 除外対象は書き込みが集中する 5 箇所: `GITHUB_WORKSPACE`・`RUNNER_TEMP`・`TEMP`・`LOCALAPPDATA\Temp`・`~/.cargo`。テストの書き込み先は全て `tempfile::TempDir` (= `%TEMP%`) で、ほかにワークスペース側の target dir とキャッシュ展開がある。
- ランナーの `TEMP` は 8.3 短縮形 (`C:\Users\RUNNER~1\...`) で入っており、Defender の除外は短縮形との照合が信頼できないため、同じ場所の長い表記 `LOCALAPPDATA\Temp` も並べて両表記でカバー。

## 計測

この PR の CI 実測で before/after を比較する (現状の基準値: ジョブ全体 3 分 47 秒、ユニットテスト 90.7 秒)。効果が薄ければ #58 の次の選択肢 (リアルタイム監視の無効化、#43 経由の軽量化) を検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Windows CI test performance by excluding workspace and temporary build directories from real-time antivirus scanning during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->