### PR TITLE
パイプ先が早期に閉じても broken pipe でパニックしない

### DIFF
--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -86,7 +86,7 @@ pub fn run(args: BundleArgs) -> Result<()> {
         |origin| display_origin(origin, &inventory, target_dir),
     );
 
-    print!("{}", assemble_output(&file, &settings, &bundled)?);
+    crate::output::write(&assemble_output(&file, &settings, &bundled)?);
     Ok(())
 }
 

--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -25,6 +25,7 @@ use crate::config;
 use crate::fs::relpath;
 use crate::library::local::LocalStore;
 use crate::library::registry::{self, STD_ID};
+use crate::output;
 
 pub fn run(args: BundleArgs) -> Result<()> {
     let store = LocalStore::discover()?;
@@ -86,7 +87,7 @@ pub fn run(args: BundleArgs) -> Result<()> {
         |origin| display_origin(origin, &inventory, target_dir),
     );
 
-    crate::output::write(&assemble_output(&file, &settings, &bundled)?);
+    output::write(&assemble_output(&file, &settings, &bundled)?);
     Ok(())
 }
 

--- a/src/commands/library.rs
+++ b/src/commands/library.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use crate::library::local::{LocalStore, validate_id};
 use crate::library::registry::{self, STD_ID};
 use crate::library::tags::{Registration, SchemaMismatch, Tags, TagsKind};
+use crate::output;
 
 pub fn run(command: LibraryCommand) -> Result<()> {
     let store = LocalStore::discover()?;
@@ -38,7 +39,7 @@ fn add(store: &LocalStore, id: &str, path: &Path) -> Result<()> {
     eprintln!("registering library `{id}`...");
     registry::register(store, id, &source_root)?;
 
-    println!("registered library `{id}`");
+    output::write_line(&format!("registered library `{id}`"));
     Ok(())
 }
 
@@ -48,7 +49,9 @@ fn add_std(store: &LocalStore, compiler: Option<&Path>) -> Result<()> {
     let requested = compiler.map_or_else(|| Config::default().compiler, Path::to_path_buf);
     let count = registry::add_std(store, &requested)?;
 
-    println!("registered the standard library (`{STD_ID}`) for {count} compiler(s)");
+    output::write_line(&format!(
+        "registered the standard library (`{STD_ID}`) for {count} compiler(s)"
+    ));
     Ok(())
 }
 
@@ -64,7 +67,7 @@ fn delete(store: &LocalStore, id: &str) -> Result<()> {
     ensure_registered(store, id)?;
     registry::remove(store, id)?;
 
-    println!("removed registration of library `{id}`");
+    output::write_line(&format!("removed registration of library `{id}`"));
     Ok(())
 }
 
@@ -81,7 +84,7 @@ fn update(store: &LocalStore, id: Option<&str>, path: Option<&Path>) -> Result<(
         None => {
             let ids = store.library_ids()?;
             if ids.is_empty() {
-                println!("no libraries to update");
+                output::write_line("no libraries to update");
                 return Ok(());
             }
             for id in ids {
@@ -99,14 +102,14 @@ fn update_one(store: &LocalStore, id: &str, path: Option<&Path>) -> Result<()> {
     ensure_registered(store, id)?;
     eprintln!("updating library `{id}`...");
     registry::reregister(store, id, path)?;
-    println!("updated library `{id}`");
+    output::write_line(&format!("updated library `{id}`"));
     Ok(())
 }
 
 fn list(store: &LocalStore) -> Result<()> {
     let ids = store.library_ids()?;
     if ids.is_empty() {
-        println!("no libraries are registered");
+        output::write_line("no libraries are registered");
         return Ok(());
     }
     // ID・種別・パスしか出さず、いずれも全スキーマバージョンに共通のため、スキーマ検証をしない
@@ -114,14 +117,18 @@ fn list(store: &LocalStore) -> Result<()> {
     // 種別を足しつつタブ区切りを保ち、grep/awk などでのパイプ処理を妨げない。
     for id in ids {
         let reg = Registration::load(&store.tags_json(&id)?)?;
-        println!("{id}\t{}\t{}", reg.kind_label(), reg.path.display());
+        output::write_line(&format!(
+            "{id}\t{}\t{}",
+            reg.kind_label(),
+            reg.path.display()
+        ));
     }
     Ok(())
 }
 
 /// `show` の 1 項目を、ラベル幅を揃えて出力する。最長ラベル `Compilers` に合わせる。
 fn show_field(label: &str, value: &str) {
-    println!("{label:<9} {value}");
+    output::write_line(&format!("{label:<9} {value}"));
 }
 
 fn show(store: &LocalStore, id: &str, verbose: bool) -> Result<()> {
@@ -159,7 +166,7 @@ fn show_tags(id: &str, tags: &Tags, verbose: bool) {
             show_field("Kind", "std (no identifier info or update detection)");
             show_field("Compilers", &compilers.len().to_string());
             for compiler in compilers {
-                println!("  {}", compiler.display());
+                output::write_line(&format!("  {}", compiler.display()));
             }
         }
         TagsKind::Library {
@@ -174,14 +181,14 @@ fn show_tags(id: &str, tags: &Tags, verbose: bool) {
             );
             if verbose {
                 show_field("Hash", hash);
-                println!("Definitions:");
+                output::write_line("Definitions:");
                 for (file, names) in files {
-                    println!("  {file}: {}", names.join(", "));
+                    output::write_line(&format!("  {file}: {}", names.join(", ")));
                 }
                 if !implements.is_empty() {
-                    println!("Implements:");
+                    output::write_line("Implements:");
                     for (file, names) in implements {
-                        println!("  {file}: {}", names.join(", "));
+                        output::write_line(&format!("  {file}: {}", names.join(", ")));
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod compiler;
 mod config;
 mod fs;
 mod library;
+mod output;
 
 use std::ffi::OsString;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,24 @@
+//! 標準出力への書き込みを一箇所に集約する。`print!`/`println!` は書き込み失敗時にパニックするが、
+//! パイプ先が `head` やページャで早期に閉じるだけの broken pipe はユーザー操作として普通に起こり得る
+//! ため、パニックにはせず黙って正常終了する。
+
+use std::io::{ErrorKind, Write as _};
+
+/// 改行を付けずにそのまま書き込む。バンドル出力のような、それ自体で完結したテキスト向け。
+pub fn write(text: &str) {
+    write_bytes(text.as_bytes());
+}
+
+/// 末尾に改行を付けて書き込む。`println!` の代替。
+pub fn write_line(text: &str) {
+    write_bytes(format!("{text}\n").as_bytes());
+}
+
+fn write_bytes(bytes: &[u8]) {
+    if let Err(err) = std::io::stdout().write_all(bytes) {
+        if err.kind() == ErrorKind::BrokenPipe {
+            std::process::exit(0);
+        }
+        panic!("failed to write to stdout: {err}");
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,6 +5,7 @@
 mod common;
 
 use std::collections::BTreeSet;
+use std::process::Stdio;
 
 use assert_cmd::prelude::*;
 use common::{Sandbox, compile_and_run};
@@ -436,6 +437,33 @@ fn embed_includes_original_source_as_comment() {
         .success()
         .stdout(predicate::str::contains("--- original source ---"))
         .stdout(predicate::str::contains("// int main() { return 0; }"));
+}
+
+#[test]
+fn broken_pipe_while_writing_output_does_not_panic() {
+    // 出力先パイプを OS のバッファ (Linux で既定 64KiB) より前に閉じ、`| head` のような早期打ち切りを
+    // 再現する。main.cpp 自身をコメントで肥大化させ、ライブラリや特定コンパイラの機能に頼らずに
+    // 出力サイズを稼ぐ (#62)。
+    let sandbox = Sandbox::new();
+    let filler = "// filler\n".repeat(20_000);
+    sandbox.write("main.cpp", &format!("{filler}int main() {{ return 0; }}\n"));
+
+    let mut child = sandbox
+        .bundle_command()
+        .args(["-k", STD, "main.cpp"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn risundle");
+
+    drop(child.stdout.take());
+    let output = child.wait_with_output().expect("wait for risundle");
+
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("panicked"),
+        "broken pipe でパニックしてはいけない: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #62

## 変更内容

- `src/output.rs` を新設し、stdout への書き込みを一箇所に集約。`ErrorKind::BrokenPipe` は静かに正常終了 (`exit(0)`) し、それ以外の書き込み失敗のみ従来通りパニックする。
- `bundle.rs` の `print!` (出力量が最も大きく実害の中心) をこの経路に差し替え。
- `library.rs` の `println!` (list/show 等) も同様に差し替え、`| head` 等のパイプ運用への耐性を揃えた。

## テスト

- `broken_pipe_while_writing_output_does_not_panic` を追加。main.cpp 自身をコメントで肥大化させて出力サイズを稼ぎ (ライブラリやコンパイラ固有の機能に頼らない)、パイプを早期に閉じても stderr に `panicked` が出ないことを確認する。
- 修正前のコードに対して実際にこのテストが失敗する (パニックを再現する) ことを手元で確認済み。
- `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test --all-features` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output handling when output is redirected or consumed by another process.
  * Prevented broken-pipe scenarios from producing panic messages or unnecessary failures.
  * Standardized output behavior across bundling and library management commands.

* **Tests**
  * Added coverage for bundling when the output stream closes unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->