### PR TITLE
system_includes をロケール非依存にする

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -68,12 +68,16 @@ fn existing_executable(candidate: PathBuf) -> Option<PathBuf> {
 ///
 /// `-v` 付きプリプロセスの標準エラーに出る探索リストを解析する。`CPATH` 等の環境変数は探索パスを
 /// 汚染する (ユーザーのライブラリが紛れる) ため取り除き、コンパイラ本来のシステム dir だけを得る。
+/// `parse_search_dirs` が探す目印文字列は英語固定なので、`LC_ALL`/`LANGUAGE` を `C` に固定し、
+/// 非英語ロケール環境でも gcc/clang の診断メッセージが翻訳されないようにする。
 pub fn system_includes(compiler: &Path) -> Result<Vec<PathBuf>> {
     let output = Command::new(compiler)
         .args(["-E", "-x", "c++", "-v", "-"])
         .env_remove("CPATH")
         .env_remove("C_INCLUDE_PATH")
         .env_remove("CPLUS_INCLUDE_PATH")
+        .env("LC_ALL", "C")
+        .env("LANGUAGE", "C")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -277,6 +277,39 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn system_includes_forces_the_c_locale() {
+        // 目印文字列 (`#include <...> search starts here:` 等) は英語固定でパースするため、
+        // 非英語ロケール環境でも gcc/clang の出力自体が英語のままになるよう LC_ALL/LANGUAGE を
+        // 固定している (#73)。偽コンパイラは、それらが `C` でなければ翻訳済みの目印を返すことで、
+        // 呼び出し側が明示的にロケールを固定していることを確かめる。
+        let temp = TempDir::new().unwrap();
+        let include_dir = temp.path().join("include");
+        fs::create_dir(&include_dir).unwrap();
+        let cc = fake_compiler(
+            temp.path(),
+            &format!(
+                "if [ \"$LC_ALL\" = C ] && [ \"$LANGUAGE\" = C ]; then\n\
+                 \x20 echo '#include <...> search starts here:' >&2\n\
+                 \x20 echo ' {}' >&2\n\
+                 \x20 echo 'End of search list.' >&2\n\
+                 else\n\
+                 \x20 echo '#include <...> の検索はここから始まります:' >&2\n\
+                 \x20 echo ' {}' >&2\n\
+                 \x20 echo '検索リストの終わりです。' >&2\n\
+                 fi",
+                include_dir.display(),
+                include_dir.display()
+            ),
+        );
+
+        assert_eq!(
+            system_includes(&cc).unwrap(),
+            vec![dunce::canonicalize(&include_dir).unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn system_includes_reports_compiler_failure_with_its_stderr() {
         let temp = TempDir::new().unwrap();
         let cc = fake_compiler(temp.path(), "echo 'unsupported option' >&2\nexit 1");


### PR DESCRIPTION
Fixes #73

## 背景

`compiler.rs` の `system_includes` は `gcc -v` (または clang) の標準エラーを `#include <...> search starts here:` / `End of search list.` という英語の目印文字列でパースしている。`LC_ALL`/`LANGUAGE` 等を固定していないため、これらの文字列が翻訳される環境では検出が失敗しうる、という理論上の懸念に対する予防的な修正。

**実機確認の結果** (Issue のコメント参照): Ubuntu 24.04 (WSL2) の gcc 14.2.0 + `language-pack-ja` では、該当メッセージの日本語訳が未整備で再現せず、clang++ 18.1.3 は多言語化機構自体を持たないため常に英語出力だった。したがって「今まさに壊れている」ケースの実機確認はできていないが、翻訳が進んだ将来の gcc や、翻訳カタログの充実度が異なる他ディストリでは起こり得るため、`LC_ALL=C`/`LANGUAGE=C` を明示する対処自体はほぼ無害な予防的ハードニングとして採用する。

## 変更内容

- `system_includes` のコンパイラ起動時に `LC_ALL=C` / `LANGUAGE=C` を設定する。

## テスト

- `system_includes_forces_the_c_locale` を追加。偽コンパイラが `LC_ALL`/`LANGUAGE` の値を見て、`C` でなければ翻訳済みの目印文字列を返すようにし、呼び出し側が明示的にロケールを固定していることを確認する。
- 修正前のコードに対してこのテストが実際に失敗する (このマシンの ambient ロケールで目印が一致せず検出に失敗する) ことを手元で確認済み。
- `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test --all-features` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler include-directory detection in non-English locales.
  * Ensures include paths are parsed consistently regardless of the system language or locale settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->