### PR TITLE
README にバンドル前後の具体例を載せる

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,93 @@
 > [!NOTE]
 > risundle が正しくバンドルできるのは、ある程度行儀の良いファイル分割をしているライブラリです。宣言と実装が別ファイルのライブラリにも対応していますが、演算子オーバーロードだけを書いたファイルなどでは定義が消え、コンパイルエラーやリンクエラーになる可能性があります。詳しい条件は [docs/compatibility.ja.md](docs/compatibility.ja.md) を参照してください。
 
+## バンドル例
+
+たとえば、`modint.hpp` を土台にして `modpow.hpp` と `combination.hpp` を重ねた、3 ファイルの自作ライブラリを `mylib` という ID で登録しておきます。
+
+```cpp
+// modint.hpp
+#pragma once
+
+constexpr long long MOD = 998244353;
+
+struct ModInt {
+    long long v = 0;
+    ModInt(long long v) : v(v % MOD) {}
+    ModInt& operator*=(ModInt o) { v = v * o.v % MOD; return *this; }
+    // ほか 100 行程度の実装
+};
+
+// modpow.hpp
+#pragma once
+#include "modint.hpp"
+
+ModInt modpow(ModInt a, long long n) {
+    ModInt r = 1;
+    for (; n > 0; n >>= 1, a *= a)
+        if (n & 1) r *= a;
+    return r;
+}
+
+// combination.hpp
+#pragma once
+#include "modint.hpp"
+
+struct Combination {
+    // 100 行程度の実装
+};
+```
+
+解答はこのライブラリから 2 ファイルを include していますが、実際に使うのは `modpow` だけです。
+
+```cpp
+// main.cpp
+#include <bits/stdc++.h>
+#include <modpow.hpp>
+#include <combination.hpp>
+
+int main() {
+    std::cout << modpow(2, 100).v << std::endl;
+}
+```
+
+これをバンドルすると、次の 1 ファイルにまとまります。
+
+```cpp
+// submission.cpp
+// Bundled with risundle v2.0.0
+#line 1 "main.cpp"
+#include <bits/stdc++.h>
+#line 1 "mylib/modpow.hpp"
+       
+#line 1 "mylib/modint.hpp"
+       
+
+constexpr long long MOD = 998244353;
+
+struct ModInt {
+    long long v = 0;
+    ModInt(long long v) : v(v % MOD) {}
+    ModInt& operator*=(ModInt o) { v = v * o.v % MOD; return *this; }
+    // ほか 100 行程度の実装
+};
+#line 3 "mylib/modpow.hpp"
+
+ModInt modpow(ModInt a, long long n) {
+    ModInt r = 1;
+    for (; n > 0; n >>= 1, a *= a)
+        if (n & 1) r *= a;
+    return r;
+}
+#line 4 "main.cpp"
+
+int main() {
+    std::cout << modpow(2, 100).v << std::endl;
+}
+```
+
+include していても使っていない `combination.hpp` は削除され、`modpow.hpp` が依存する `modint.hpp` は維持されます。標準ライブラリは `#include` のまま残ります。`#line` はコンパイラの診断を元ファイルの行番号で表示させるためのもので、ジャッジのエラーも元ファイル基準で読めます。
+
 ## インストール
 
 [Rust ツールチェーン](https://www.rust-lang.org/tools/install) と、GCC 互換の C++ コンパイラ (`g++` や `clang++` など) が必要です。risundle が依存する `-E`/`-M`/`-v` オプションを持たない MSVC には対応していません。

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,8 +28,7 @@
 // modint.hpp
 #pragma once
 
-constexpr long long MOD = 998244353;
-
+template <long long MOD>
 struct ModInt {
     long long v = 0;
     ModInt(long long v) : v(v % MOD) {}
@@ -41,8 +40,9 @@ struct ModInt {
 #pragma once
 #include "modint.hpp"
 
-ModInt modpow(ModInt a, long long n) {
-    ModInt r = 1;
+template <long long MOD>
+ModInt<MOD> modpow(ModInt<MOD> a, long long n) {
+    ModInt<MOD> r = 1;
     for (; n > 0; n >>= 1, a *= a)
         if (n & 1) r *= a;
     return r;
@@ -52,6 +52,7 @@ ModInt modpow(ModInt a, long long n) {
 #pragma once
 #include "modint.hpp"
 
+template <long long MOD>
 struct Combination {
     // 100 行程度の実装
 };
@@ -65,8 +66,10 @@ struct Combination {
 #include <modpow.hpp>
 #include <combination.hpp>
 
+using mint = ModInt<998244353>;
+
 int main() {
-    std::cout << modpow(2, 100).v << std::endl;
+    std::cout << modpow(mint(2), 100).v << std::endl;
 }
 ```
 
@@ -82,8 +85,7 @@ int main() {
 #line 1 "mylib/modint.hpp"
        
 
-constexpr long long MOD = 998244353;
-
+template <long long MOD>
 struct ModInt {
     long long v = 0;
     ModInt(long long v) : v(v % MOD) {}
@@ -92,16 +94,19 @@ struct ModInt {
 };
 #line 3 "mylib/modpow.hpp"
 
-ModInt modpow(ModInt a, long long n) {
-    ModInt r = 1;
+template <long long MOD>
+ModInt<MOD> modpow(ModInt<MOD> a, long long n) {
+    ModInt<MOD> r = 1;
     for (; n > 0; n >>= 1, a *= a)
         if (n & 1) r *= a;
     return r;
 }
 #line 4 "main.cpp"
 
+using mint = ModInt<998244353>;
+
 int main() {
-    std::cout << modpow(2, 100).v << std::endl;
+    std::cout << modpow(mint(2), 100).v << std::endl;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ For example, register a three-file library under the ID `mylib`: `modpow.hpp` an
 // modint.hpp
 #pragma once
 
-constexpr long long MOD = 998244353;
-
+template <long long MOD>
 struct ModInt {
     long long v = 0;
     ModInt(long long v) : v(v % MOD) {}
@@ -41,8 +40,9 @@ struct ModInt {
 #pragma once
 #include "modint.hpp"
 
-ModInt modpow(ModInt a, long long n) {
-    ModInt r = 1;
+template <long long MOD>
+ModInt<MOD> modpow(ModInt<MOD> a, long long n) {
+    ModInt<MOD> r = 1;
     for (; n > 0; n >>= 1, a *= a)
         if (n & 1) r *= a;
     return r;
@@ -52,6 +52,7 @@ ModInt modpow(ModInt a, long long n) {
 #pragma once
 #include "modint.hpp"
 
+template <long long MOD>
 struct Combination {
     // ~100 lines of implementation
 };
@@ -65,8 +66,10 @@ The solution includes two files from this library, but only actually uses `modpo
 #include <modpow.hpp>
 #include <combination.hpp>
 
+using mint = ModInt<998244353>;
+
 int main() {
-    std::cout << modpow(2, 100).v << std::endl;
+    std::cout << modpow(mint(2), 100).v << std::endl;
 }
 ```
 
@@ -82,8 +85,7 @@ Bundling it produces this single file.
 #line 1 "mylib/modint.hpp"
        
 
-constexpr long long MOD = 998244353;
-
+template <long long MOD>
 struct ModInt {
     long long v = 0;
     ModInt(long long v) : v(v % MOD) {}
@@ -92,16 +94,19 @@ struct ModInt {
 };
 #line 3 "mylib/modpow.hpp"
 
-ModInt modpow(ModInt a, long long n) {
-    ModInt r = 1;
+template <long long MOD>
+ModInt<MOD> modpow(ModInt<MOD> a, long long n) {
+    ModInt<MOD> r = 1;
     for (; n > 0; n >>= 1, a *= a)
         if (n & 1) r *= a;
     return r;
 }
 #line 4 "main.cpp"
 
+using mint = ModInt<998244353>;
+
 int main() {
-    std::cout << modpow(2, 100).v << std::endl;
+    std::cout << modpow(mint(2), 100).v << std::endl;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,93 @@ risundle bundles your competitive programming solution, libraries included, into
 > [!NOTE]
 > risundle bundles correctly only libraries with reasonably well-behaved file layouts. Libraries that split declarations and implementations across files are supported too, but a file containing only operator overloads, for example, can lose its definitions and fail to compile or link after bundling. See [docs/compatibility.md](docs/compatibility.md) for the exact conditions.
 
+## Bundling example
+
+For example, register a three-file library under the ID `mylib`: `modpow.hpp` and `combination.hpp` built on top of `modint.hpp`.
+
+```cpp
+// modint.hpp
+#pragma once
+
+constexpr long long MOD = 998244353;
+
+struct ModInt {
+    long long v = 0;
+    ModInt(long long v) : v(v % MOD) {}
+    ModInt& operator*=(ModInt o) { v = v * o.v % MOD; return *this; }
+    // ~100 more lines of implementation
+};
+
+// modpow.hpp
+#pragma once
+#include "modint.hpp"
+
+ModInt modpow(ModInt a, long long n) {
+    ModInt r = 1;
+    for (; n > 0; n >>= 1, a *= a)
+        if (n & 1) r *= a;
+    return r;
+}
+
+// combination.hpp
+#pragma once
+#include "modint.hpp"
+
+struct Combination {
+    // ~100 lines of implementation
+};
+```
+
+The solution includes two files from this library, but only actually uses `modpow`.
+
+```cpp
+// main.cpp
+#include <bits/stdc++.h>
+#include <modpow.hpp>
+#include <combination.hpp>
+
+int main() {
+    std::cout << modpow(2, 100).v << std::endl;
+}
+```
+
+Bundling it produces this single file.
+
+```cpp
+// submission.cpp
+// Bundled with risundle v2.0.0
+#line 1 "main.cpp"
+#include <bits/stdc++.h>
+#line 1 "mylib/modpow.hpp"
+       
+#line 1 "mylib/modint.hpp"
+       
+
+constexpr long long MOD = 998244353;
+
+struct ModInt {
+    long long v = 0;
+    ModInt(long long v) : v(v % MOD) {}
+    ModInt& operator*=(ModInt o) { v = v * o.v % MOD; return *this; }
+    // ~100 more lines of implementation
+};
+#line 3 "mylib/modpow.hpp"
+
+ModInt modpow(ModInt a, long long n) {
+    ModInt r = 1;
+    for (; n > 0; n >>= 1, a *= a)
+        if (n & 1) r *= a;
+    return r;
+}
+#line 4 "main.cpp"
+
+int main() {
+    std::cout << modpow(2, 100).v << std::endl;
+}
+```
+
+The included but unused `combination.hpp` is removed, while `modint.hpp` is kept because `modpow.hpp` depends on it. The standard library stays as `#include`. The `#line` directives make compiler diagnostics point at the original files, so judge errors also read in your original line numbers.
+
 ## Installation
 
 You need the [Rust toolchain](https://www.rust-lang.org/tools/install) and a C++ compiler with a GCC-compatible driver interface, such as `g++` or `clang++` (MSVC is not supported, as it lacks the `-E`/`-M`/`-v` interface risundle relies on).


### PR DESCRIPTION
Closes #99

## 概要

README (日英) の NOTE とインストールの間に「バンドル例」の節を追加する。例を見て使いたくなってからインストールへ進む、という順番を意図して、インストールより前に置いた。

- 題材: `modint.hpp` を土台に `modpow.hpp` と `combination.hpp` を重ねた 3 ファイルのライブラリ。解答は 2 ファイルを include するが `modpow` しか使わない。
- 見せる挙動: 使っていない `combination.hpp` の削除・依存する `modint.hpp` の維持・標準ライブラリの `#include` 温存・`#line` の意味。
- `ModInt` はテンプレートにしてある。テンプレートを含むライブラリでも問題なくバンドルできることを、例自体で示すため。
- 掲載する `submission.cpp` はドキュメント方針 (出力の実物を転載しない) の例外として実物を貼る。ツールの顔であることと、クレジット行のバージョンで古さに気づけることが理由。

### 検証 (README には載せない、この PR の作業記録)

日英それぞれのコメント言語でライブラリを実際に登録・バンドルして掲載の実物を取得し、その出力が g++ でコンパイルでき、実行結果 (2^100 mod 998244353 = 882499718) が正しいことまで確認した。実行結果自体は README の例の焦点 (バンドル前後のコード変換) ではないため、README には掲載しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)