### PR TITLE
CLI help を自己完結の説明に書き直し、library をサブコマンドとして統合する

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@
 
 ```
 src/
-  main.rs            配線・argv 振り分け
+  main.rs            配線・サブコマンド振り分け
   cli.rs             clap 定義
   config.rs          .risundlerc.toml の読み取り
   commands/          サブコマンドの受け口 (library.rs / bundle.rs)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,27 +6,40 @@ use std::path::PathBuf;
 
 /// A C++ source bundler with tree-shaking for competitive programming.
 ///
-/// When no subcommand is given, bundles the specified C++ file.
+/// Bundles <FILE> and the registered libraries it includes into a single
+/// file for submission, keeping only the headers it actually uses.
+/// Register libraries beforehand with risundle library add.
 #[derive(Parser, Debug)]
 #[command(
     name = "risundle",
     version,
-    after_help = "For library management, see `risundle library --help`."
+    override_usage = "risundle [OPTIONS] <FILE> [-- <COMPILER OPTIONS>...]\n       risundle library <COMMAND>",
+    after_help = "For library management, see risundle library --help.",
+    after_long_help = "Examples:\n  risundle library add mylib ~/cp/library\n  risundle main.cpp > submission.cpp\n\nFor library management, see risundle library --help."
 )]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "CLI フラグの列挙であり、bool の数は引数の数を映しているだけで状態機械の複雑さではない"
 )]
 pub struct BundleArgs {
-    /// Path to the compiler to use
+    /// Path to the compiler to use [default: g++]
+    ///
+    /// Any GCC-compatible compiler works (g++, clang++, ...). A default can
+    /// also be set in .risundlerc.toml.
     #[arg(short, long)]
     pub compiler: Option<PathBuf>,
 
-    /// Also keep a library unexpanded, out of tree-shaking (can be repeated)
+    /// Also keep a library unexpanded, out of tree-shaking (can be repeated) [default: std]
+    ///
+    /// Takes the ID given at registration. Effective keep = (configured keep
+    /// + every --keep) - every --no-keep.
     #[arg(short, long = "keep", value_name = "ID")]
     pub keep: Vec<String>,
 
     /// Stop keeping a library (can be repeated; beats --keep)
+    ///
+    /// Removes the ID from the configured keep and --keep, so the library is
+    /// expanded and tree-shaken like any other.
     #[arg(long = "no-keep", value_name = "ID")]
     pub no_keep: Vec<String>,
 
@@ -42,18 +55,27 @@ pub struct BundleArgs {
     #[arg(short = 'n', long = "no-check")]
     pub no_check: bool,
 
-    /// Expand the source without tree-shaking
+    /// Expand the source without tree-shaking (fallback)
+    ///
+    /// Use when tree-shaking removed a definition the solution needs: every
+    /// library except the kept ones stays fully expanded. Unlike --keep, the
+    /// libraries are still expanded rather than left as #include.
     #[arg(long = "no-tree-shaking")]
     pub no_tree_shaking: bool,
 
     /// Ignore any .risundlerc.toml, behaving as if none exists
+    ///
+    /// The nearest .risundlerc.toml above <FILE> normally supplies defaults
+    /// for the compiler, options, keep, and embed.
     #[arg(long = "no-config")]
     pub no_config: bool,
 
     /// C++ source file to bundle
     pub file: PathBuf,
 
-    /// Extra options after `--` passed straight to the compiler
+    /// Extra options after -- passed straight to the compiler
+    ///
+    /// Appended to the options configured in .risundlerc.toml.
     #[arg(last = true, value_name = "COMPILER OPTIONS")]
     pub options: Vec<String>,
 }
@@ -76,6 +98,9 @@ impl BundleArgs {
 // help・usage 上のコマンド名が `risundle library` として表示される。
 
 /// Register and manage libraries
+///
+/// Register a library once with add; bundling (risundle <FILE>) then
+/// recognizes its includes and tree-shakes them.
 #[derive(Parser, Debug)]
 #[command(version)]
 pub struct LibraryCli {
@@ -87,14 +112,18 @@ pub struct LibraryCli {
 pub enum LibraryCommand {
     /// Register a library
     Add {
-        /// Library ID
+        /// Library ID, used to refer to the library later (e.g. in --keep)
         id: String,
-        /// Include path
+        /// Include path: the library root directory
         path: PathBuf,
     },
-    /// Register the standard library (`std`) (auto-detects the compiler's system include paths)
+    /// Register the standard library (std) from a compiler's system include paths
+    ///
+    /// Each call adds the compiler to the recognized set and merges its
+    /// system include paths in, so multiple compilers can be used side by
+    /// side.
     AddStd {
-        /// Compiler used to detect system include paths (defaults to g++)
+        /// Compiler whose system include paths to detect [default: g++]
         compiler: Option<PathBuf>,
     },
     /// Remove a library registration
@@ -102,7 +131,7 @@ pub enum LibraryCommand {
         /// Library ID
         id: String,
     },
-    /// Apply library updates (updates all libraries if id is omitted)
+    /// Apply library changes (updates all libraries if ID is omitted)
     Update {
         /// Library ID
         id: Option<String>,
@@ -115,7 +144,7 @@ pub enum LibraryCommand {
     Show {
         /// Library ID
         id: String,
-        /// Include the hash and per-file defined identifiers
+        /// Also show the hash, per-file defined identifiers, and implementation target names
         #[arg(short, long)]
         verbose: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,5 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
-
-// clap ではトップレベルの必須 positional と optional subcommand を共存させられないため、
-// `library` 管理用の `LibraryCli` とはパーサを分け、エントリポイントで argv を振り分ける。
 
 /// A C++ source bundler with tree-shaking for competitive programming.
 ///
@@ -13,10 +10,33 @@ use std::path::PathBuf;
 #[command(
     name = "risundle",
     version,
+    propagate_version = true,
+    subcommand_negates_reqs = true,
+    args_conflicts_with_subcommands = true,
     override_usage = "risundle [OPTIONS] <FILE> [-- <COMPILER OPTIONS>...]\n       risundle library <COMMAND>",
-    after_help = "For library management, see risundle library --help.",
-    after_long_help = "Examples:\n  risundle library add mylib ~/cp/library\n  risundle main.cpp > submission.cpp\n\nFor library management, see risundle library --help."
+    after_long_help = "Examples:\n  risundle library add mylib ~/cp/library\n  risundle main.cpp > submission.cpp"
 )]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
+    #[command(flatten)]
+    pub bundle: BundleArgs,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Register and manage libraries
+    ///
+    /// Register a library once with add; bundling (risundle <FILE>) then
+    /// recognizes its includes and tree-shakes them.
+    Library {
+        #[command(subcommand)]
+        command: LibraryCommand,
+    },
+}
+
+#[derive(Args, Debug)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "CLI フラグの列挙であり、bool の数は引数の数を映しているだけで状態機械の複雑さではない"
@@ -71,7 +91,10 @@ pub struct BundleArgs {
     pub no_config: bool,
 
     /// C++ source file to bundle
-    pub file: PathBuf,
+    // subcommand_negates_reqs の都合で型は Option だが required は付いており、
+    // バンドル経路 (subcommand 無し) では clap が存在を保証する。
+    #[arg(required = true)]
+    pub file: Option<PathBuf>,
 
     /// Extra options after -- passed straight to the compiler
     ///
@@ -92,20 +115,6 @@ impl BundleArgs {
             None
         }
     }
-}
-
-// エントリポイントで argv の先頭を `risundle library` に差し替えて渡すため、
-// help・usage 上のコマンド名が `risundle library` として表示される。
-
-/// Register and manage libraries
-///
-/// Register a library once with add; bundling (risundle <FILE>) then
-/// recognizes its includes and tree-shakes them.
-#[derive(Parser, Debug)]
-#[command(version)]
-pub struct LibraryCli {
-    #[command(subcommand)]
-    pub command: LibraryCommand,
 }
 
 #[derive(Subcommand, Debug)]
@@ -156,29 +165,28 @@ mod tests {
 
     #[test]
     fn options_after_file_are_parsed_as_risundle_flags() {
-        let args = BundleArgs::try_parse_from(["risundle", "main.cpp", "-e"]).unwrap();
-        assert!(args.embed);
-        assert!(args.options.is_empty());
+        let cli = Cli::try_parse_from(["risundle", "main.cpp", "-e"]).unwrap();
+        assert!(cli.bundle.embed);
+        assert!(cli.bundle.options.is_empty());
     }
 
     #[test]
     fn double_dash_separates_compiler_options() {
-        let args =
-            BundleArgs::try_parse_from(["risundle", "main.cpp", "--", "-std=gnu++20", "-O2"])
-                .unwrap();
-        assert_eq!(args.options, ["-std=gnu++20", "-O2"]);
+        let cli =
+            Cli::try_parse_from(["risundle", "main.cpp", "--", "-std=gnu++20", "-O2"]).unwrap();
+        assert_eq!(cli.bundle.options, ["-std=gnu++20", "-O2"]);
     }
 
     #[test]
     fn hyphen_arguments_before_double_dash_are_rejected() {
-        assert!(BundleArgs::try_parse_from(["risundle", "main.cpp", "-O2"]).is_err());
+        assert!(Cli::try_parse_from(["risundle", "main.cpp", "-O2"]).is_err());
     }
 
     #[test]
     fn embed_pair_resolves_to_the_last_flag() {
         let parse = |argv: &[&str]| {
             let argv = [&["risundle", "main.cpp"], argv].concat();
-            BundleArgs::try_parse_from(argv).unwrap().embed_override()
+            Cli::try_parse_from(argv).unwrap().bundle.embed_override()
         };
         assert_eq!(parse(&[]), None);
         assert_eq!(parse(&["-e"]), Some(true));
@@ -186,5 +194,27 @@ mod tests {
         // 後勝ち: 同時指定はコマンドライン上で後にある方が有効。
         assert_eq!(parse(&["--embed", "--no-embed"]), Some(false));
         assert_eq!(parse(&["--no-embed", "--embed"]), Some(true));
+    }
+
+    #[test]
+    fn library_is_parsed_as_a_subcommand_not_a_file() {
+        let cli = Cli::try_parse_from(["risundle", "library", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Library {
+                command: LibraryCommand::List
+            })
+        ));
+        assert_eq!(cli.bundle.file, None);
+    }
+
+    #[test]
+    fn the_file_is_required_when_no_subcommand_is_given() {
+        assert!(Cli::try_parse_from(["risundle"]).is_err());
+    }
+
+    #[test]
+    fn bundle_flags_conflict_with_the_library_subcommand() {
+        assert!(Cli::try_parse_from(["risundle", "-e", "library", "list"]).is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,11 @@ pub enum Command {
     ///
     /// Register a library once with add; bundling (risundle <FILE>) then
     /// recognizes its includes and tree-shakes them.
+    // GNU Coding Standards に合わせ、-V はどの階層でも risundle 本体のバージョンを
+    // 答える (propagate_version)。表示名の既定はハイフン結合 (risundle-library 等) で
+    // 実在しないバイナリ名になってしまい、clap は display_name を伝播しないため、
+    // 全サブコマンドで risundle に上書きする。
+    #[command(display_name = "risundle")]
     Library {
         #[command(subcommand)]
         command: LibraryCommand,
@@ -117,9 +122,11 @@ impl BundleArgs {
     }
 }
 
+// 各 display_name の理由は Command::Library のコメントを参照。
 #[derive(Subcommand, Debug)]
 pub enum LibraryCommand {
     /// Register a library
+    #[command(display_name = "risundle")]
     Add {
         /// Library ID, used to refer to the library later (e.g. in --keep)
         id: String,
@@ -131,16 +138,19 @@ pub enum LibraryCommand {
     /// Each call adds the compiler to the recognized set and merges its
     /// system include paths in, so multiple compilers can be used side by
     /// side.
+    #[command(display_name = "risundle")]
     AddStd {
         /// Compiler whose system include paths to detect [default: g++]
         compiler: Option<PathBuf>,
     },
     /// Remove a library registration
+    #[command(display_name = "risundle")]
     Delete {
         /// Library ID
         id: String,
     },
     /// Apply library changes (updates all libraries if ID is omitted)
+    #[command(display_name = "risundle")]
     Update {
         /// Library ID
         id: Option<String>,
@@ -148,8 +158,10 @@ pub enum LibraryCommand {
         path: Option<PathBuf>,
     },
     /// List registered libraries
+    #[command(display_name = "risundle")]
     List,
     /// Show library details
+    #[command(display_name = "risundle")]
     Show {
         /// Library ID
         id: String,
@@ -216,5 +228,21 @@ mod tests {
     #[test]
     fn bundle_flags_conflict_with_the_library_subcommand() {
         assert!(Cli::try_parse_from(["risundle", "-e", "library", "list"]).is_err());
+    }
+
+    // GNU Coding Standards 流: どの階層の、どんな打ちかけのコマンドでも、--version は
+    // 他の引数 (必須引数の欠落も含む) に優先して risundle 本体のバージョンを答える。
+    #[test]
+    fn version_answers_as_risundle_at_every_level() {
+        for argv in [
+            vec!["risundle", "--version"],
+            vec!["risundle", "main.cpp", "--version"],
+            vec!["risundle", "library", "--version"],
+            vec!["risundle", "library", "add", "--version"],
+        ] {
+            let err = Cli::try_parse_from(argv).unwrap_err();
+            assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+            assert!(err.to_string().starts_with("risundle "));
+        }
     }
 }

--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -48,6 +48,8 @@ pub fn run(args: BundleArgs) -> Result<()> {
         options,
         ..
     } = args;
+    // subcommand が無い経路では clap が <FILE> の必須指定を検証済み (cli::BundleArgs::file を参照)。
+    let file = file.expect("clap should enforce <FILE> on the bundle path");
 
     let Resolution {
         settings,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,22 +8,14 @@ mod library;
 mod output;
 mod update_check;
 
-use std::ffi::OsString;
-
 use clap::Parser;
 
-use crate::cli::{BundleArgs, LibraryCli};
+use crate::cli::{Cli, Command};
 
 fn main() -> anyhow::Result<()> {
-    let argv: Vec<OsString> = std::env::args_os().collect();
-
-    // 先頭引数が `library` のときだけ管理用パーサへ、それ以外は全てバンドル実行へ振り分ける。
-    if argv.get(1).is_some_and(|arg| arg == "library") {
-        // 先頭 2 要素 (コマンド名と `library`) を、usage 表示用の `risundle library` に差し替える。
-        let library_argv =
-            std::iter::once(OsString::from("risundle library")).chain(argv.into_iter().skip(2));
-        commands::library::run(LibraryCli::parse_from(library_argv).command)
-    } else {
-        commands::bundle::run(BundleArgs::parse_from(argv))
+    let cli = Cli::parse();
+    match cli.command {
+        Some(Command::Library { command }) => commands::library::run(command),
+        None => commands::bundle::run(cli.bundle),
     }
 }


### PR DESCRIPTION
Resolves #26

## 概要

CLI help を「その場で読み切れる自己完結の説明」に書き直し、library をトップレベルのサブコマンドとしてパーサに統合しました。Issue のコメントに整理した 10 項目すべてに対応しています。

## 変更内容

### help の書き直し (docs)

- `-c` と `-k` の既定値 (`g++` / `std`) を説明の 1 行目に明記
- 長い help (`--help`) の 2 段落目に文脈を追加: keep の合成規則、`--no-tree-shaking` のフォールバック用途と `--keep` との違い、`add-std` の加算式の挙動、`.risundlerc.toml` の存在
- `--help` の末尾に登録 → バンドルの Examples を追加 (`-h` には出さず一覧性を維持)
- `show -v` の説明に実装先の名前 (implementation target names) を追加 (v2 追随漏れ)
- help 内のバッククォートを全廃し、英語 README と用語を整合

### パーサ統合 (feat)

`risundle --help` の Commands セクションに library が本物のサブコマンドとして現れるようにしました。従来は argv の先頭を見て 2 つの独立したパーサへ振り分けていたため、help に library が出ず末尾の案内文で補う案を Issue コメントでは示していましたが、走査で発見できる本物のセクションの方が UX 上優れると判断し、統合まで進めました。

- clap の `subcommand_negates_reqs` + `args_conflicts_with_subcommands` で必須 positional `<FILE>` と optional subcommand を共存させる
- `<FILE>` は clap の都合で `Option<PathBuf>` になるが `required = true` は維持され、バンドル経路では clap が存在を保証する
- main.rs の argv 振り分けと `LibraryCli` を廃止し、architecture.md の記述を追随

### --version の GNU 対応 (feat)

GNU Coding Standards の「`--version` は他のオプションや引数に優先してバージョンを表示し、成功終了する」に合わせ、どの階層で打っても risundle 本体のバージョンを答えるようにしました。

- `risundle library add -V` のような打ちかけのコマンド (必須引数の欠落を含む) でも `risundle 2.0.0` を表示して exit 0
- 従来の `risundle library -V` は `risundle library 2.0.0` という表示でしたが、バージョンは本体で 1 つなので表示名も `risundle` に統一 (clap 既定のハイフン結合 `risundle-library` は実在しないバイナリ名を名乗るため `display_name` で上書き)

### 補足

- typo (`risundle librray ...`) は従来「ファイルが読めない」という見当違いのエラーでしたが、parse 時の引数エラー (usage 付き) になりました

## テスト

- cli.rs に回帰テスト 4 件を追加 (subcommand 解釈・`<FILE>` 必須・フラグとの競合・全階層の `--version`)
- `cargo fmt --check` / `cargo test` (219 件全通過) / `cargo clippy --all-targets` (pedantic) を確認
- `-h` / `--help` / `library --help` / 各サブコマンドの help と、全階層の `-V`/`--version` の実出力を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
