### PR TITLE
v2.1.0 にバージョンアップ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "risundle"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risundle"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 authors = ["TwoSquirrels"]
 description = "A C++ bundler with tree-shaking for competitive programming"

--- a/README.ja.md
+++ b/README.ja.md
@@ -77,7 +77,7 @@ int main() {
 
 ```cpp
 // submission.cpp
-// Bundled with risundle v2.0.0
+// Bundled with risundle v2.1.0
 #line 1 "main.cpp"
 #include <bits/stdc++.h>
 #line 1 "mylib/modpow.hpp"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Bundling it produces this single file.
 
 ```cpp
 // submission.cpp
-// Bundled with risundle v2.0.0
+// Bundled with risundle v2.1.0
 #line 1 "main.cpp"
 #include <bits/stdc++.h>
 #line 1 "mylib/modpow.hpp"


### PR DESCRIPTION
v2.0.0 以降の機能追加に伴うリリース準備です。マージ後に `v2.1.0` タグでリリースします。

## minor (v2.1.0) と判断した理由

後方互換な機能追加が含まれるため、patch ではなく minor です。破壊的変更はありません。

- **更新チェック機能 (#53)** — `library` サブコマンド実行時に crates.io で新バージョンを確認して案内。環境変数 `RISUNDLE_NO_UPDATE_CHECK` が公開インターフェースに追加
- **CLI help の改善と library サブコマンドのパーサ統合 (#26)** — `risundle --help` の Commands セクションに library が現れるように。help 全体を自己完結の説明に書き直し
- **全階層での `-V`/`--version` (#26)** — GNU Coding Standards に合わせ、`risundle library add -V` のような従来エラーだった呼び出しでも本体バージョンを表示して成功終了

## patch 相当の修正

- broken pipe でパニックしない (#62)
- `system_includes` のロケール非依存化 (#73)
- 更新チェックの案内メッセージ調整、CI・ドキュメント更新

## このブランチの変更

- Cargo.toml / Cargo.lock のバージョンを 2.1.0 へ
- README のバンドル例のクレジット行を v2.1.0 に追随

🤖 Generated with [Claude Code](https://claude.com/claude-code)
